### PR TITLE
Correct German wording for "about" and "device lock"

### DIFF
--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -60,7 +60,7 @@
 
     <!-- action settings -->
     <string name="action_settings">Einstellungen</string>
-    <string name="action_about">Über</string>
+    <string name="action_about">Über Keep Alive</string>
     <string name="action_logdisplay">Debug Logs</string>
     <string name="about_dialog_title">Über Keep Alive</string>
 
@@ -183,7 +183,7 @@
     <!-- Monitored Apps strings -->
     <string name="monitored_apps_title">Überwachungsmethode</string>
     <string name="monitored_apps_dialog_title">Wählen Sie 1 oder mehrere Apps auf Ihrem Gerät aus</string>
-    <string name="monitored_apps_dialog_message">Die Nutzung der ausgewählten App(s) wird verwendet, um festzustellen, wann Ihr Gerät zuletzt verwendet wurde. Um zur Gerätesperre/-entsperrung zurückzukehren, drücken Sie \'Löschen\'.</string>
+    <string name="monitored_apps_dialog_message">Die Nutzung der ausgewählten App(s) wird verwendet, um festzustellen, wann Ihr Gerät zuletzt verwendet wurde. Um zur Methode Displaysperre zurückzukehren, drücken Sie \'Löschen\'.</string>
     <string name="monitored_apps_chosen_title">Ausgewählte App(s)</string>
     <string name="monitored_apps_usage_history_message">Diese Ereignisse können nicht immer auf Benutzeraktivität zurückzuführen sein. Bitte überprüfen Sie sie sorgfältig, bevor Sie diese App auswählen.</string>
     <string name="monitored_apps_recently_used_title">Kürzlich verwendete Apps (letzte 72 Stunden)</string>


### PR DESCRIPTION
## German translation fixes

Two small corrections to the German (`values-de-rDE`) strings:

- **About menu:** changed the bare »Über« to »Über Keep Alive«, which reads less abruptly and gives the label a subject.
- **Device lock wording:** replaced »Gerätesperre« with »Displaysperre«, matching the term Android itself uses in its German UI.

Both verified on Android 17.