### PR TITLE
Check SEND_SMS permission from the background alarm cycle

### DIFF
--- a/app/src/main/java/io/keepalive/android/AppController.kt
+++ b/app/src/main/java/io/keepalive/android/AppController.kt
@@ -26,6 +26,7 @@ class AppController : Application() {
         const val SMS_ALERT_FAILURE_NOTIFICATION_ID = 4
         const val ALERT_SERVICE_NOTIFICATION_ID = 5
         const val WEBHOOK_ALERT_SENT_NOTIFICATION_ID = 6
+        const val PERMISSION_REVOKED_NOTIFICATION_ID = 7
 
         // when doing a sanity check to see if we can see ANY events, this is the # of hours
         //  to use with getLastDeviceActivity().  if the user has a higher value set it

--- a/app/src/main/java/io/keepalive/android/PrefKeys.kt
+++ b/app/src/main/java/io/keepalive/android/PrefKeys.kt
@@ -43,6 +43,9 @@ object PrefKeys {
     const val NEXT_ALARM_TIMESTAMP = "NextAlarmTimestamp"
     const val LAST_ALERT_AT = "LastAlertAt"
 
+    // when the user was last notified about a revoked SMS permission
+    const val SMS_PERMISSION_NOTIFIED_AT = "sms_permission_notified_at"
+
     // runtime state in device-protected storage (Direct Boot)
     const val LAST_ALARM_STAGE = "last_alarm_stage"
     const val LAST_ACTIVITY_TIMESTAMP = "last_activity_timestamp"

--- a/app/src/main/java/io/keepalive/android/receivers/AlarmReceiver.kt
+++ b/app/src/main/java/io/keepalive/android/receivers/AlarmReceiver.kt
@@ -1,13 +1,18 @@
 package io.keepalive.android.receivers
 
 
+import android.Manifest
 import android.app.ActivityManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import androidx.core.content.edit
 import io.keepalive.android.*
 
 
@@ -47,11 +52,10 @@ class AlarmReceiver : BroadcastReceiver() {
                 return
             }
 
-            /*
-            if (!PermissionManager(context, null).checkHavePermissions()) {
-                Log.d(tag, "We still need some permissions?!")
-            }
-            */
+            // surface a revoked SEND_SMS permission from the background (issue #192).
+            // the alert check still runs regardless — the send path has its own
+            // failure notification if an SMS attempt actually fails
+            checkSmsPermissionStillGranted(context, prefs)
 
             // get the current alarm stage from the intent extras
             val alarmStage = getAlarmStage(context, intent)
@@ -63,6 +67,53 @@ class AlarmReceiver : BroadcastReceiver() {
 
         } catch (e: Exception) {
             DebugLogger.d(tag, context.getString(R.string.debug_log_failed_processing_alarm), e)
+        }
+    }
+
+    // A permission revoked after setup (battery sweep, OS update, someone
+    // adjusting settings) was previously only detected when the app was next
+    // opened. Since this receiver already wakes periodically, use it to check
+    // that SEND_SMS is still granted and notify the user if not (issue #192).
+    private fun checkSmsPermissionStillGranted(context: Context, prefs: SharedPreferences) {
+        try {
+            // only relevant if an enabled SMS contact is configured
+            val smsContacts: MutableList<SMSEmergencyContactSetting> =
+                loadJSONSharedPreference(prefs, PrefKeys.PHONE_NUMBER_SETTINGS)
+            if (smsContacts.none { it.isEnabled && it.phoneNumber.isNotEmpty() }) {
+                return
+            }
+
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.SEND_SMS) ==
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                // permission is fine - clear the notified marker so a future
+                //  revocation notifies immediately
+                if (prefs.getLong(PrefKeys.SMS_PERMISSION_NOTIFIED_AT, 0L) != 0L) {
+                    prefs.edit { putLong(PrefKeys.SMS_PERMISSION_NOTIFIED_AT, 0L) }
+                }
+                return
+            }
+
+            DebugLogger.d(tag, context.getString(R.string.debug_log_sms_permission_revoked))
+
+            // notify at most once per day while the permission stays revoked
+            val lastNotifiedAt = prefs.getLong(PrefKeys.SMS_PERMISSION_NOTIFIED_AT, 0L)
+            if (System.currentTimeMillis() - lastNotifiedAt < 24 * 60 * 60 * 1000L) {
+                return
+            }
+
+            // tapping the notification opens MainActivity, which runs the normal
+            //  permission checks and prompts
+            AlertNotificationHelper(context).sendNotification(
+                context.getString(R.string.sms_permission_revoked_notification_title),
+                context.getString(R.string.sms_permission_revoked_notification_text),
+                AppController.PERMISSION_REVOKED_NOTIFICATION_ID
+            )
+
+            prefs.edit { putLong(PrefKeys.SMS_PERMISSION_NOTIFIED_AT, System.currentTimeMillis()) }
+        } catch (e: Exception) {
+            // never let the permission check interfere with the alert check
+            Log.e(tag, "Error checking SMS permission from background", e)
         }
     }
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -132,6 +132,8 @@
     <string name="sms_alert_failure_notification_text_with_error">Beim Versuch, eine Alarm-SMS zu senden, ist ein Fehler aufgetreten: %1$s</string>
     <string name="sms_service_failure_notification_title">Alarm-SMS kann nicht gesendet werden</string>
     <string name="sms_service_failure_notification_text">Beim Versuch, eine Alarm-SMS zu senden, ist ein Fehler aufgetreten.  Bitte überprüfen Sie, ob Sie eine aktive SIM-Karte haben.</string>
+    <string name="sms_permission_revoked_notification_title">SMS-Berechtigung wurde entzogen!</string>
+    <string name="sms_permission_revoked_notification_text">Keep Alive kann keine SMS-Alarme mehr senden. Tippen Sie hier, um die App zu öffnen und die SMS-Berechtigung erneut zu erteilen.</string>
     <string name="alert_service_notification_title">Alarm wird gesendet…</string>
     <string name="alert_service_notification_message">Alarm(e) werden an Ihre konfigurierten Kontakte gesendet, bitte warten.</string>
 
@@ -333,6 +335,7 @@
 
     <!-- AlarmReceiver.kt -->
     <string name="debug_log_alarm_just_fired">Alarm gerade ausgelöst!</string>
+    <string name="debug_log_sms_permission_revoked">Die Berechtigung SEND_SMS ist nicht mehr erteilt!</string>
     <string name="debug_log_app_not_enabled_alarm_went_off">App ist nicht aktiviert, warum wurde der Alarm ausgelöst?!</string>
     <string name="debug_log_alarm_time_comparison">Uhrzeit ist %1$s UTC, Alarm sollte um %2$s UTC ausgelöst werden, was %3$d Sekunden her ist</string>
     <string name="debug_log_failed_processing_alarm">Fehler bei der Alarmverarbeitung:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -132,6 +132,8 @@
     <string name="sms_alert_failure_notification_text_with_error">Ocurrió un error al intentar enviar la alerta SMS: %1$s</string>
     <string name="sms_service_failure_notification_title">No se puede enviar la alerta SMS</string>
     <string name="sms_service_failure_notification_text">Ocurrió un error al intentar enviar la alerta SMS, verifica que tengas una SIM activa</string>
+    <string name="sms_permission_revoked_notification_title">¡El permiso de SMS ha sido revocado!</string>
+    <string name="sms_permission_revoked_notification_text">Keep Alive ya no puede enviar alertas por SMS. Toque aquí para abrir la aplicación y volver a conceder el permiso de SMS.</string>
     <string name="alert_service_notification_title">Enviando alerta…</string>
     <string name="alert_service_notification_message">Se están enviando alertas a tus contactos configurados, por favor espera.</string>
 
@@ -333,6 +335,7 @@
 
     <!-- AlarmReceiver.kt -->
     <string name="debug_log_alarm_just_fired">¡La alarma acaba de activarse!</string>
+    <string name="debug_log_sms_permission_revoked">¡El permiso SEND_SMS ya no está concedido!</string>
     <string name="debug_log_app_not_enabled_alarm_went_off">La app no está activada, ¿por qué se activó la alarma?</string>
     <string name="debug_log_alarm_time_comparison">La hora es %1$s UTC, la alarma debía activarse a las %2$s UTC, que fue hace %3$d segundos</string>
     <string name="debug_log_failed_processing_alarm">Error al procesar la alarma:</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -132,6 +132,8 @@
     <string name="sms_alert_failure_notification_text_with_error">Une erreur s\'est produite lors de la tentative d\'envoi d\'un SMS d\'alerte: %1$s</string>
     <string name="sms_service_failure_notification_title">Impossible de transmettre l\'alerte SMS</string>
     <string name="sms_service_failure_notification_text">Une erreur s\'est produite lors de la tentative d\'envoi d\'un SMS d\'alerte, veuillez vérifier que vous disposez d\'une carte SIM active</string>
+    <string name="sms_permission_revoked_notification_title">L\'autorisation SMS a été révoquée!</string>
+    <string name="sms_permission_revoked_notification_text">Keep Alive ne peut plus envoyer d\'alertes SMS. Touchez ici pour ouvrir l\'application et accorder de nouveau l\'autorisation SMS.</string>
     <string name="alert_service_notification_title">Envoi de l\'alerte en cours…</string>
     <string name="alert_service_notification_message">L\'alerte (ou les alertes) est en cours d\'envoi à vos contacts configurés, veuillez patienter.</string>
 
@@ -333,6 +335,7 @@
 
     <!-- AlarmReceiver.kt -->
     <string name="debug_log_alarm_just_fired">L\'alarme vient de se déclencher!</string>
+    <string name="debug_log_sms_permission_revoked">L\'autorisation SEND_SMS n\'est plus accordée!</string>
     <string name="debug_log_app_not_enabled_alarm_went_off">L\'application n\'est pas activée, pourquoi l\'alarme s\'est-elle déclenchée?!</string>
     <string name="debug_log_alarm_time_comparison">L\'heure est %1$s UTC, l\'alarme était censée se déclencher à %2$s UTC, c\'est-à-dire il y a %3$d secondes</string>
     <string name="debug_log_failed_processing_alarm">Échec lors du traitement de l\'alarme:</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -132,6 +132,8 @@
         <string name="sms_alert_failure_notification_text_with_error">Si è verificato un errore durante il tentativo di invio di un SMS di avviso: %1$s</string>  
         <string name="sms_service_failure_notification_title">Impossibile trasmettere l\'avviso SMS</string>  
         <string name="sms_service_failure_notification_text">Si è verificato un errore durante il tentativo di invio di un SMS di avviso, si prega di verificare di avere una SIM attiva</string>  
+        <string name="sms_permission_revoked_notification_title">L\'autorizzazione SMS è stata revocata!</string>
+        <string name="sms_permission_revoked_notification_text">Keep Alive non può più inviare avvisi SMS. Tocca qui per aprire l\'app e concedere di nuovo l\'autorizzazione SMS.</string>
         <string name="alert_service_notification_title">Invio dell\'avviso in corso…</string>
         <string name="alert_service_notification_message">L\'avviso (o gli avvisi) è in corso di invio ai tuoi contatti configurati, si prega di attendere.</string>  
       
@@ -333,6 +335,7 @@
   
 <!-- AlarmReceiver.kt -->  
 <string name="debug_log_alarm_just_fired">L\'allarme è appena scattato!</string>  
+<string name="debug_log_sms_permission_revoked">L\'autorizzazione SEND_SMS non è più concessa!</string>
 <string name="debug_log_app_not_enabled_alarm_went_off">L\'applicazione non è abilitata, perché l\'allarme è scattato?!</string>  
 <string name="debug_log_alarm_time_comparison">L\'ora è %1$s UTC, l\'allarme doveva scattare a %2$s UTC, ovvero %3$d secondi fa</string>  
 <string name="debug_log_failed_processing_alarm">Impossibile elaborare l\'allarme:</string>  

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -132,6 +132,8 @@
     <string name="sms_alert_failure_notification_text_with_error">Wystąpił błąd podczas wysyłania Alertu SMS: %1$s</string>
     <string name="sms_service_failure_notification_title">Nie udało się wysłać Alert SMS</string>
     <string name="sms_service_failure_notification_text">Wystąpił błąd podczas wysyłania Alertu SMS, upewnij się, że masz aktywną kartę SIM</string>
+    <string name="sms_permission_revoked_notification_title">Uprawnienie SMS zostało cofnięte!</string>
+    <string name="sms_permission_revoked_notification_text">Keep Alive nie może już wysyłać alarmów SMS. Dotknij tutaj, aby otworzyć aplikację i ponownie przyznać uprawnienie SMS.</string>
     <string name="alert_service_notification_title">Wysyłanie alertu…</string>
     <string name="alert_service_notification_message">Alert(y) są wysyłane do skonfigurowanych kontaktów, proszę czekać.</string>
 
@@ -333,6 +335,7 @@
 
     <!-- AlarmReceiver.kt -->
     <string name="debug_log_alarm_just_fired">Alarm właśnie się uruchomił!</string>
+    <string name="debug_log_sms_permission_revoked">Uprawnienie SEND_SMS nie jest już przyznane!</string>
     <string name="debug_log_app_not_enabled_alarm_went_off">Aplikacja nie jest włączona, dlaczego alarm się uruchomił?!</string>
     <string name="debug_log_alarm_time_comparison">Czas to %1$s UTC, alarm miał się uruchomić o %2$s UTC, co było %3$d sekund temu</string>
     <string name="debug_log_failed_processing_alarm">Nie udało się przetworzyć alarmu:</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -132,6 +132,8 @@
     <string name="sms_alert_failure_notification_text_with_error">Произошла ошибка при попытке отправить SMS-оповещение: %1$s</string>
     <string name="sms_service_failure_notification_title">Невозможно отправить SMS-оповещение</string>
     <string name="sms_service_failure_notification_text">Произошла ошибка при попытке отправить SMS-сообщение с оповещением. Убедитесь, что у вас активна SIM-карта.</string>
+    <string name="sms_permission_revoked_notification_title">Разрешение на отправку SMS было отозвано!</string>
+    <string name="sms_permission_revoked_notification_text">Keep Alive больше не может отправлять SMS-оповещения. Нажмите здесь, чтобы открыть приложение и снова предоставить разрешение на SMS.</string>
     <string name="alert_service_notification_title">Отправка оповещения…</string>
     <string name="alert_service_notification_message">Оповещение(я) отправляются вашим настроенным контактам, пожалуйста, подождите.</string>
 
@@ -333,6 +335,7 @@
 
     <!-- AlarmReceiver.kt -->
     <string name="debug_log_alarm_just_fired">Будильник только что сработал!</string>
+    <string name="debug_log_sms_permission_revoked">Разрешение SEND_SMS больше не предоставлено!</string>
     <string name="debug_log_app_not_enabled_alarm_went_off">Приложение не включено, почему сработал будильник?!</string>
     <string name="debug_log_alarm_time_comparison">Время %1$s UTC, будильник должен был сработать в %2$s UTC, что было %3$d секунд назад</string>
     <string name="debug_log_failed_processing_alarm">Не удалось обработать будильник:</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -132,6 +132,8 @@
     <string name="sms_alert_failure_notification_text_with_error">发送短信时发生错误: %1$s</string>
     <string name="sms_service_failure_notification_title">无法发送提醒短信</string>
     <string name="sms_service_failure_notification_text">发送提醒短信时发生错误，请插入有效的SIM卡。</string>
+    <string name="sms_permission_revoked_notification_title">短信权限已被撤销！</string>
+    <string name="sms_permission_revoked_notification_text">Keep Alive 无法再发送短信警报。点击此处打开应用并重新授予短信权限。</string>
     <string name="alert_service_notification_title">正在发送提醒…</string>
     <string name="alert_service_notification_message">提醒消息正在发送给您的联系人，请稍候。</string>
 
@@ -333,6 +335,7 @@
 
     <!-- AlarmReceiver.kt -->
     <string name="debug_log_alarm_just_fired">Alarm just fired!</string>
+    <string name="debug_log_sms_permission_revoked">SEND_SMS 权限已不再授予！</string>
     <string name="debug_log_app_not_enabled_alarm_went_off">App is not enabled, why did the alarm go off?!</string>
     <string name="debug_log_alarm_time_comparison">Time is %1$s UTC, alarm was supposed to go off at %2$s UTC, which was %3$d seconds ago</string>
     <string name="debug_log_failed_processing_alarm">Failed while processing alarm:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
     <string name="sms_alert_failure_notification_text_with_error">Error occurred while attempting to send Alert SMS: %1$s</string>
     <string name="sms_service_failure_notification_title">Unable to send Alert SMS</string>
     <string name="sms_service_failure_notification_text">Error occurred while attempting to send Alert SMS, please verify you have an active SIM</string>
+    <string name="sms_permission_revoked_notification_title">SMS permission has been revoked!</string>
+    <string name="sms_permission_revoked_notification_text">Keep Alive can no longer send SMS Alerts. Tap here to open the app and grant the SMS permission again.</string>
     <string name="alert_service_notification_title">Sending Alert…</string>
     <string name="alert_service_notification_message">Alert(s) are being sent to your configured contacts, please wait.</string>
 
@@ -345,6 +347,7 @@
 
     <!-- AlarmReceiver.kt -->
     <string name="debug_log_alarm_just_fired">Alarm just fired!</string>
+    <string name="debug_log_sms_permission_revoked">SEND_SMS permission is no longer granted!</string>
     <string name="debug_log_app_not_enabled_alarm_went_off">App is not enabled, why did the alarm go off?!</string>
     <string name="debug_log_alarm_time_comparison">Time is %1$s UTC, alarm was supposed to go off at %2$s UTC, which was %3$d seconds ago</string>
     <string name="debug_log_failed_processing_alarm">Failed while processing alarm:</string>

--- a/app/src/test/java/io/keepalive/android/receivers/AlarmReceiverTest.kt
+++ b/app/src/test/java/io/keepalive/android/receivers/AlarmReceiverTest.kt
@@ -1,8 +1,12 @@
 package io.keepalive.android.receivers
 
+import android.Manifest
+import android.app.Application
+import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
+import io.keepalive.android.AppController
 import io.keepalive.android.doAlertCheck
 import io.keepalive.android.getAppSharedPreferences
 import io.mockk.every
@@ -10,10 +14,14 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 
 private const val ALERT_FUNCTIONS_KT = "io.keepalive.android.AlertFunctionsKt"
 
@@ -105,5 +113,84 @@ class AlarmReceiverTest {
         AlarmReceiver().onReceive(appCtx, intent)
 
         verify(exactly = 1) { doAlertCheck(any<Context>(), "final") }
+    }
+
+    // --- background SEND_SMS permission check (issue #192) -----------------
+
+    private val enabledContactJson =
+        """[{"phoneNumber":"5550100","alertMessage":"test","isEnabled":true,"includeLocation":false}]"""
+
+    private fun seedSmsContact(json: String = enabledContactJson) {
+        getAppSharedPreferences(appCtx).edit()
+            .putString("PHONE_NUMBER_SETTINGS", json)
+            .commit()
+    }
+
+    private fun grantPermissions(vararg permissions: String) {
+        shadowOf(appCtx as Application).grantPermissions(*permissions)
+    }
+
+    private fun hasPermissionNotification(): Boolean {
+        val nm = appCtx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        return shadowOf(nm).getNotification(null, AppController.PERMISSION_REVOKED_NOTIFICATION_ID) != null
+    }
+
+    @Test fun `revoked SMS permission with enabled contact posts a notification`() {
+        // POST_NOTIFICATIONS granted so the helper can post; SEND_SMS not granted
+        grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        seedSmsContact()
+
+        AlarmReceiver().onReceive(appCtx, Intent().putExtra("AlarmStage", "periodic"))
+
+        assertTrue("permission-revoked notification should be posted",
+            hasPermissionNotification())
+        assertNotEquals("notified-at marker should be written",
+            0L, getAppSharedPreferences(appCtx).getLong("sms_permission_notified_at", 0L))
+        // the alert check must still run — the permission check never blocks it
+        verify(exactly = 1) { doAlertCheck(any<Context>(), "periodic") }
+    }
+
+    @Test fun `revoked SMS permission without any enabled contact stays silent`() {
+        grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        seedSmsContact("""[{"phoneNumber":"5550100","alertMessage":"test","isEnabled":false,"includeLocation":false}]""")
+
+        AlarmReceiver().onReceive(appCtx, Intent().putExtra("AlarmStage", "periodic"))
+
+        assertTrue("no notification expected when no enabled contact",
+            !hasPermissionNotification())
+    }
+
+    @Test fun `revoked SMS permission notifies at most once per day`() {
+        grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        seedSmsContact()
+
+        AlarmReceiver().onReceive(appCtx, Intent().putExtra("AlarmStage", "periodic"))
+        val firstNotifiedAt = getAppSharedPreferences(appCtx).getLong("sms_permission_notified_at", 0L)
+
+        // clear the posted notification, then fire again — the rate limit
+        // (not the still-posted guard) must prevent a second post
+        val nm = appCtx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.cancelAll()
+
+        AlarmReceiver().onReceive(appCtx, Intent().putExtra("AlarmStage", "periodic"))
+
+        assertTrue("no second notification within 24h", !hasPermissionNotification())
+        assertEquals("notified-at marker unchanged on rate-limited run",
+            firstNotifiedAt,
+            getAppSharedPreferences(appCtx).getLong("sms_permission_notified_at", 0L))
+    }
+
+    @Test fun `granted SMS permission clears the notified marker`() {
+        grantPermissions(Manifest.permission.POST_NOTIFICATIONS, Manifest.permission.SEND_SMS)
+        seedSmsContact()
+        getAppSharedPreferences(appCtx).edit()
+            .putLong("sms_permission_notified_at", 12345L)
+            .commit()
+
+        AlarmReceiver().onReceive(appCtx, Intent().putExtra("AlarmStage", "periodic"))
+
+        assertTrue("no notification when permission is granted", !hasPermissionNotification())
+        assertEquals("marker cleared once permission is granted again",
+            0L, getAppSharedPreferences(appCtx).getLong("sms_permission_notified_at", 0L))
     }
 }


### PR DESCRIPTION
A permission revoked after setup (battery sweep, OS update, someone adjusting settings) was previously only detected when the app was next opened - for a set-and-forget app that leaves the install silently unable to send SMS alerts until it is too late.

The periodic AlarmReceiver now verifies SEND_SMS is still granted whenever an enabled SMS contact is configured, and posts a notification (tap opens the app) if it was revoked. Rate-limited to once per day; the marker clears when the permission is restored so a future revocation notifies immediately. The check never blocks the alert check itself, and the first pass is deliberately scoped to SEND_SMS per the issue discussion.

New strings translated for all 7 locales; covered by new AlarmReceiverTest cases.

Fixes #192

Generated with [Claude Code](https://claude.com/claude-code)