### PR TITLE
Show a warning state when monitoring has no alert recipient

### DIFF
--- a/app/src/main/java/io/keepalive/android/MainActivity.kt
+++ b/app/src/main/java/io/keepalive/android/MainActivity.kt
@@ -505,6 +505,21 @@ class MainActivity : AppCompatActivity() {
                         monitoringMessageTextView.text =
                             getString(R.string.monitoring_permissions_required_message)
 
+                    } else if (!hasActiveAlertChannel(sharedPrefs)) {
+
+                        // monitoring is running but there is no enabled contact (or
+                        //  webhook) so no alert could actually be delivered - don't
+                        //  show a reassuring green state (issue #187)
+                        DebugLogger.d(tag, getString(R.string.debug_log_no_alert_channel))
+
+                        monitoringStatusTextView.text =
+                            getString(R.string.monitoring_no_recipient_title)
+                        monitoringStatusTextView.setTextColor(
+                            getColorCompat(this, R.color.monitoringImpaired)
+                        )
+                        monitoringMessageTextView.text =
+                            getString(R.string.monitoring_no_recipient_message)
+
                     } else {
                         Log.d(tag, "Don't need any permissions, we are all set?!")
 

--- a/app/src/main/java/io/keepalive/android/UtilityFunctions.kt
+++ b/app/src/main/java/io/keepalive/android/UtilityFunctions.kt
@@ -46,6 +46,32 @@ data class MonitoredAppDetails(
     val className: String
 )
 
+// whether any alert delivery channel is currently usable: an enabled SMS
+//  contact with a phone number, a call contact, or (in webhook builds) an
+//  enabled and configured webhook. used by the main screen so monitoring is
+//  not presented as healthy when no alert could actually be delivered (issue #187)
+fun hasActiveAlertChannel(sharedPrefs: SharedPreferences): Boolean {
+    val smsContacts: MutableList<SMSEmergencyContactSetting> =
+        loadJSONSharedPreference(sharedPrefs, PrefKeys.PHONE_NUMBER_SETTINGS)
+
+    if (smsContacts.any { it.isEnabled && it.phoneNumber.isNotEmpty() }) {
+        return true
+    }
+
+    if (!sharedPrefs.getString(PrefKeys.CONTACT_PHONE, "").isNullOrEmpty()) {
+        return true
+    }
+
+    if (BuildConfig.INCLUDE_WEBHOOK &&
+        sharedPrefs.getBoolean(PrefKeys.WEBHOOK_ENABLED, false) &&
+        !sharedPrefs.getString(PrefKeys.WEBHOOK_URL, "").isNullOrEmpty()
+    ) {
+        return true
+    }
+
+    return false
+}
+
 // load a JSON string from shared preferences and convert it to a list of objects
 // used with the SMSEmergencyContactSetting and RestPeriods
 inline fun <reified T> loadJSONSharedPreference(

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -87,6 +87,8 @@
     <string name="monitoring_no_activity_detected_title">Überwachung nicht möglich</string>
     <string name="monitoring_permissions_required_title">Berechtigungen erforderlich</string>
     <string name="monitoring_no_activity_detected_message">Die Überwachung ist aktiviert, aber in den letzten %1$s Stunden wurde keine Aktivität festgestellt.  Bitte stellen Sie sicher, dass Sie eine Bildschirmsperre aktiviert haben und die Zugriffsrechte für die Nutzung erteilt haben.</string>
+    <string name="monitoring_no_recipient_title">Kein Alarm-Empfänger</string>
+    <string name="monitoring_no_recipient_message">Die Überwachung läuft, aber kein Notfallkontakt ist aktiv, daher kann kein Alarm gesendet werden. Bitte fügen Sie in den Einstellungen einen Notfallkontakt hinzu oder aktivieren Sie einen.</string>
     <string name="monitoring_permissions_required_message">Die Überwachung ist aktiviert, aber es wurden nicht alle Berechtigungen erteilt.  Bitte klicken Sie unten auf die Schaltfläche "Berechtigungen erteilen".</string>
     <string name="alarm_message_too_long_message">Die Nachricht darf nicht länger als 160 Zeichen sein.</string>
     <string name="phone_number_invalid_message">Bitte geben Sie eine gültige Telefonnummer ein.</string>
@@ -321,6 +323,7 @@
     <!-- MainActivity.kt -->
     <string name="debug_log_no_alarm_or_monitoring_disabled">Kein Alarm gefunden oder Überwachung deaktiviert</string>
     <string name="debug_log_no_events_found_lock_screen">Keine Ereignisse gefunden, möglicherweise kein Sperrbildschirm?</string>
+    <string name="debug_log_no_alert_channel">Die Überwachung ist aktiviert, aber es ist kein Alarm-Empfänger konfiguriert!</string>
     <string name="debug_log_no_active_alarm_showing_restart_button">Kein aktiver Alarm gefunden, Schaltfläche zum Neustart wird angezeigt</string>
     <string name="debug_log_failed_getting_sms_manager_disable_button">Fehler beim Abrufen des SMS-Managers? SMS-Testschaltfläche deaktivieren</string>
     <string name="debug_log_current_alarm_time">Aktueller Alarm für %1$s Ortszeit eingestellt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -87,6 +87,8 @@
     <string name="monitoring_no_activity_detected_title">Monitoreo no posible</string>
     <string name="monitoring_permissions_required_title">Permisos necesarios</string>
     <string name="monitoring_no_activity_detected_message">El monitoreo está activado pero no se ha detectado actividad en las últimas %1$s horas. Asegúrate de tener una pantalla de bloqueo activada y de haber concedido el permiso de Acceso de uso.</string>
+    <string name="monitoring_no_recipient_title">Sin destinatario de alerta</string>
+    <string name="monitoring_no_recipient_message">La supervisión está en marcha, pero ningún contacto de emergencia está activo, por lo que no se puede enviar ninguna alerta. Añada o active un contacto de emergencia en los ajustes.</string>
     <string name="monitoring_permissions_required_message">El monitoreo está activado pero no se han concedido todos los permisos. Toca el botón "Conceder permisos" de abajo.</string>
     <string name="alarm_message_too_long_message">El mensaje no puede tener más de 160 caracteres.</string>
     <string name="phone_number_invalid_message">Por favor, ingresa un número de teléfono válido.</string>
@@ -321,6 +323,7 @@
     <!-- MainActivity.kt -->
     <string name="debug_log_no_alarm_or_monitoring_disabled">No se encontró ninguna alarma o el monitoreo está desactivado</string>
     <string name="debug_log_no_events_found_lock_screen">No se encontraron eventos, ¿quizás no hay pantalla de bloqueo?</string>
+    <string name="debug_log_no_alert_channel">¡La supervisión está activada pero no hay ningún destinatario de alerta configurado!</string>
     <string name="debug_log_no_active_alarm_showing_restart_button">No se encontró ninguna alarma activa, mostrando el botón para reiniciar</string>
     <string name="debug_log_failed_getting_sms_manager_disable_button">¿Error al obtener el gestor de SMS? Desactivando el botón de prueba de SMS</string>
     <string name="debug_log_current_alarm_time">Alarma actual establecida para las %1$s hora local</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -87,6 +87,8 @@
     <string name="monitoring_no_activity_detected_title">Surveillance impossible</string>
     <string name="monitoring_permissions_required_title">Autorisations requises</string>
     <string name="monitoring_no_activity_detected_message">La surveillance est activée, mais aucune activité n\'a été détectée au cours des %1$s dernières heures. Veuillez vous assurer que votre écran de verrouillage est activé et que vous avez accordé les autorisations d\'accès à l\'utilisation.</string>
+    <string name="monitoring_no_recipient_title">Aucun destinataire d\'alerte</string>
+    <string name="monitoring_no_recipient_message">La surveillance est en cours, mais aucun contact d\'urgence n\'est actif, donc aucune alerte ne peut être envoyée. Veuillez ajouter ou activer un contact d\'urgence dans les paramètres.</string>
     <string name="monitoring_permissions_required_message">La surveillance est activée, mais toutes les autorisations n\'ont pas été accordées. Veuillez cliquer sur le bouton « Accorder des autorisations » ci-dessous.</string>
     <string name="alarm_message_too_long_message">Le message ne peut pas contenir plus de 160 caractères.</string>
     <string name="phone_number_invalid_message">Veuillez saisir un numéro de téléphone valide.</string>
@@ -321,6 +323,7 @@
     <!-- MainActivity.kt -->
     <string name="debug_log_no_alarm_or_monitoring_disabled">Aucune alarme trouvée ou surveillance désactivée</string>
     <string name="debug_log_no_events_found_lock_screen">Aucun événement trouvé, peut-être pas d\'écran de verrouillage?</string>
+    <string name="debug_log_no_alert_channel">La surveillance est activée, mais aucun destinataire d\'alerte n\'est configuré!</string>
     <string name="debug_log_no_active_alarm_showing_restart_button">Aucune alarme active trouvée, affichage du bouton de redémarrage</string>
     <string name="debug_log_failed_getting_sms_manager_disable_button">Échec de l\'obtention du gestionnaire de SMS? Désactivation du bouton de test SMS</string>
     <string name="debug_log_current_alarm_time">Alarme actuelle définie pour %1$s heure locale</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -87,6 +87,8 @@
         <string name="monitoring_no_activity_detected_title">Monitoraggio impossibile</string>  
         <string name="monitoring_permissions_required_title">Autorizzazioni richieste</string>  
         <string name="monitoring_no_activity_detected_message">Il monitoraggio è attivato, ma non è stata rilevata alcuna attività nelle ultime %1$s ore. Assicurati che il tuo blocco schermo sia attivo e di aver concesso le autorizzazioni di accesso all\'utilizzo.</string>  
+        <string name="monitoring_no_recipient_title">Nessun destinatario di avviso</string>
+        <string name="monitoring_no_recipient_message">Il monitoraggio è in corso, ma nessun contatto di emergenza è attivo, quindi non è possibile inviare alcun avviso. Aggiungi o attiva un contatto di emergenza nelle impostazioni.</string>
         <string name="monitoring_permissions_required_message">Il monitoraggio è attivato, ma non tutte le autorizzazioni sono state concesse. Fare clic sul pulsante "Concedi autorizzazioni" sottostante.</string>  
         <string name="alarm_message_too_long_message">Il messaggio non può contenere più di 160 caratteri.</string>  
         <string name="phone_number_invalid_message">Si prega di inserire un numero di telefono valido.</string>  
@@ -321,6 +323,7 @@
 <!-- MainActivity.kt -->  
 <string name="debug_log_no_alarm_or_monitoring_disabled">Nessun allarme trovato o monitoraggio disabilitato</string>  
 <string name="debug_log_no_events_found_lock_screen">Nessun evento trovato, forse nessuna schermata di blocco?</string>  
+<string name="debug_log_no_alert_channel">Il monitoraggio è attivato ma non è configurato alcun destinatario di avviso!</string>
 <string name="debug_log_no_active_alarm_showing_restart_button">Nessun allarme attivo trovato, visualizzazione del pulsante di riavvio</string>  
 <string name="debug_log_failed_getting_sms_manager_disable_button">Impossibile ottenere il gestore SMS? Disabilitazione del pulsante di test SMS</string>  
 <string name="debug_log_current_alarm_time">Allarme attuale impostato per le %1$s ora locale</string>  

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -87,6 +87,8 @@
     <string name="monitoring_no_activity_detected_title">Monitorowanie nie jest możliwe</string>
     <string name="monitoring_permissions_required_title">Potrzebuje Uprawnień</string>
     <string name="monitoring_no_activity_detected_message">Monitorowanie jest włączone ale nie wykryto żadnej aktywności przez ostatnie %1$s godzin. Sprawdź czy masz skonfigurowany ekran blokady i czy aplikacja ma Dostęp do Informacji o Korzystaniu z Aplikacji.</string>
+    <string name="monitoring_no_recipient_title">Brak odbiorcy alarmu</string>
+    <string name="monitoring_no_recipient_message">Monitorowanie działa, ale żaden kontakt alarmowy nie jest aktywny, więc nie można wysłać alarmu. Dodaj lub włącz kontakt alarmowy w ustawieniach.</string>
     <string name="monitoring_permissions_required_message">Monitorowanie jest włączone lecz nie wszystkie uprawnienia zostały przyznane. Kliknij przycisk "Udziel Uprawnień" poniżej.</string>
     <string name="alarm_message_too_long_message">Wiadomość nie może mieć więcej niż 160 znaków.</string>
     <string name="phone_number_invalid_message">Wpisz poprawny numer telefonu.</string>
@@ -321,6 +323,7 @@
     <!-- MainActivity.kt -->
     <string name="debug_log_no_alarm_or_monitoring_disabled">Nie znaleziono alarmu lub monitorowanie jest wyłączone</string>
     <string name="debug_log_no_events_found_lock_screen">Nie znaleziono zdarzeń, może nie ma ekranu blokady?</string>
+    <string name="debug_log_no_alert_channel">Monitorowanie jest włączone, ale nie skonfigurowano odbiorcy alarmu!</string>
     <string name="debug_log_no_active_alarm_showing_restart_button">Nie znaleziono aktywnego alarmu, pokazywanie przycisku ponownego uruchomienia</string>
     <string name="debug_log_failed_getting_sms_manager_disable_button">Nie udało się pobrać menedżera SMS? Wyłączanie przycisku testowego SMS</string>
     <string name="debug_log_current_alarm_time">Bieżący alarm ustawiony na %1$s czasu lokalnego</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -87,6 +87,8 @@
     <string name="monitoring_no_activity_detected_title">Мониторинг невозможен</string>
     <string name="monitoring_permissions_required_title">Предоставьте разрешения</string>
     <string name="monitoring_no_activity_detected_message">Мониторинг включен, но за последние %1$s часов активности не обнаружено. Убедитесь, что у вас включен экран блокировки и предоставлены разрешения на использование.</string>
+    <string name="monitoring_no_recipient_title">Нет получателя оповещения</string>
+    <string name="monitoring_no_recipient_message">Мониторинг работает, но ни один экстренный контакт не активен, поэтому оповещение не может быть отправлено. Добавьте или включите экстренный контакт в настройках.</string>
     <string name="monitoring_permissions_required_message">Мониторинг включен, но предоставлены не все разрешения. Нажмите кнопку \'Предоставить разрешения\' ниже.</string>
     <string name="alarm_message_too_long_message">Сообщение не может содержать более 160 символов.</string>
     <string name="phone_number_invalid_message">Введите корректный телефонный номер</string>
@@ -321,6 +323,7 @@
     <!-- MainActivity.kt -->
     <string name="debug_log_no_alarm_or_monitoring_disabled">Будильник не найден или мониторинг отключен</string>
     <string name="debug_log_no_events_found_lock_screen">События не найдены, возможно, нет экрана блокировки?</string>
+    <string name="debug_log_no_alert_channel">Мониторинг включён, но получатель оповещения не настроен!</string>
     <string name="debug_log_no_active_alarm_showing_restart_button">Активный будильник не найден, отображение кнопки перезапуска</string>
     <string name="debug_log_failed_getting_sms_manager_disable_button">Не удалось получить менеджер SMS? Отключение кнопки тестирования SMS</string>
     <string name="debug_log_current_alarm_time">Текущий будильник установлен на %1$s местного времени</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -87,6 +87,8 @@
     <string name="monitoring_no_activity_detected_title">无法进行监测</string>
     <string name="monitoring_permissions_required_title">需要授予权限</string>
     <string name="monitoring_no_activity_detected_message">监测器已启用，但在过去 %1$s 小时内未检测到任何活动。 请确保屏幕锁定已启用并授予了使用情况访问权限。</string>
+    <string name="monitoring_no_recipient_title">没有警报接收人</string>
+    <string name="monitoring_no_recipient_message">监控正在运行，但没有已启用的紧急联系人，因此无法发送警报。请在设置中添加或启用紧急联系人。</string>
     <string name="monitoring_permissions_required_message">监测器已启用，但尚未授予必要权限。 请点击下面的“授予权限”按钮。</string>
     <string name="alarm_message_too_long_message">短信不得超过 160 个字符。</string>
     <string name="phone_number_invalid_message">请输入一个有效的电话号码。</string>
@@ -321,6 +323,7 @@
     <!-- MainActivity.kt -->
     <string name="debug_log_no_alarm_or_monitoring_disabled">No alarm found or monitoring is disabled</string>
     <string name="debug_log_no_events_found_lock_screen">No events found, may not have lock screen?</string>
+    <string name="debug_log_no_alert_channel">监控已启用，但未配置警报接收人！</string>
     <string name="debug_log_no_active_alarm_showing_restart_button">No active alarm found, showing button to restart</string>
     <string name="debug_log_failed_getting_sms_manager_disable_button">Failed to get SMS manager? Disabling SMS test button</string>
     <string name="debug_log_current_alarm_time">Current alarm set for %1$s local time</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,8 @@
     <string name="monitoring_no_activity_detected_title">Monitoring Not Possible</string>
     <string name="monitoring_permissions_required_title">Permissions Required</string>
     <string name="monitoring_no_activity_detected_message">Monitoring is enabled but no activity has been detected in the last %1$s hours. Please ensure you have a lock screen enabled and have granted Usage access permissions.</string>
+    <string name="monitoring_no_recipient_title">No Alert Recipient</string>
+    <string name="monitoring_no_recipient_message">Monitoring is running but no emergency contact is active, so no Alert can be sent. Please add or enable an emergency contact in the Settings.</string>
     <string name="monitoring_permissions_required_message">Monitoring is enabled but not all permissions have been granted. Please click the "Grant Permissions" button below.</string>
     <string name="alarm_message_too_long_message">The message cannot be more than 160 characters.</string>
     <string name="phone_number_invalid_message">Please enter a valid phone number.</string>
@@ -333,6 +335,7 @@
     <!-- MainActivity.kt -->
     <string name="debug_log_no_alarm_or_monitoring_disabled">No alarm found or monitoring is disabled</string>
     <string name="debug_log_no_events_found_lock_screen">No events found, may not have lock screen?</string>
+    <string name="debug_log_no_alert_channel">Monitoring is enabled but no alert recipient is configured!</string>
     <string name="debug_log_no_active_alarm_showing_restart_button">No active alarm found, showing button to restart</string>
     <string name="debug_log_failed_getting_sms_manager_disable_button">Failed to get SMS manager? Disabling SMS test button</string>
     <string name="debug_log_current_alarm_time">Current alarm set for %1$s local time</string>

--- a/app/src/test/java/io/keepalive/android/HasActiveAlertChannelTest.kt
+++ b/app/src/test/java/io/keepalive/android/HasActiveAlertChannelTest.kt
@@ -1,0 +1,77 @@
+package io.keepalive.android
+
+import io.keepalive.android.testing.FakeSharedPreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [hasActiveAlertChannel], the check behind the "No Alert Recipient"
+ * main-screen state (issue #187): monitoring must not be presented as a
+ * healthy green "active" when no alert could actually be delivered.
+ */
+class HasActiveAlertChannelTest {
+
+    private val prefs = FakeSharedPreferences()
+
+    private fun putContacts(json: String) {
+        prefs.edit().putString(PrefKeys.PHONE_NUMBER_SETTINGS, json).commit()
+    }
+
+    @Test fun `nothing configured means no channel`() {
+        assertFalse(hasActiveAlertChannel(prefs))
+    }
+
+    @Test fun `enabled SMS contact with a number is a channel`() {
+        putContacts("""[{"phoneNumber":"5550100","alertMessage":"x","isEnabled":true,"includeLocation":false}]""")
+        assertTrue(hasActiveAlertChannel(prefs))
+    }
+
+    @Test fun `disabled SMS contact is not a channel`() {
+        putContacts("""[{"phoneNumber":"5550100","alertMessage":"x","isEnabled":false,"includeLocation":false}]""")
+        assertFalse(hasActiveAlertChannel(prefs))
+    }
+
+    @Test fun `enabled SMS contact with a blank number is not a channel`() {
+        putContacts("""[{"phoneNumber":"","alertMessage":"x","isEnabled":true,"includeLocation":false}]""")
+        assertFalse(hasActiveAlertChannel(prefs))
+    }
+
+    @Test fun `one enabled contact among disabled ones is a channel`() {
+        putContacts(
+            """[{"phoneNumber":"5550100","alertMessage":"x","isEnabled":false,"includeLocation":false},
+                {"phoneNumber":"5550101","alertMessage":"x","isEnabled":true,"includeLocation":false}]"""
+        )
+        assertTrue(hasActiveAlertChannel(prefs))
+    }
+
+    @Test fun `call contact is a channel`() {
+        prefs.edit().putString(PrefKeys.CONTACT_PHONE, "5550102").commit()
+        assertTrue(hasActiveAlertChannel(prefs))
+    }
+
+    @Test fun `webhook only counts in webhook builds and only when enabled and configured`() {
+        prefs.edit()
+            .putBoolean(PrefKeys.WEBHOOK_ENABLED, true)
+            .putString(PrefKeys.WEBHOOK_URL, "https://example.com/hook")
+            .commit()
+
+        if (BuildConfig.INCLUDE_WEBHOOK) {
+            assertTrue(hasActiveAlertChannel(prefs))
+
+            // enabled flag off -> not a channel
+            prefs.edit().putBoolean(PrefKeys.WEBHOOK_ENABLED, false).commit()
+            assertFalse(hasActiveAlertChannel(prefs))
+
+            // enabled but no URL -> not a channel
+            prefs.edit()
+                .putBoolean(PrefKeys.WEBHOOK_ENABLED, true)
+                .putString(PrefKeys.WEBHOOK_URL, "")
+                .commit()
+            assertFalse(hasActiveAlertChannel(prefs))
+        } else {
+            // builds without webhook support ignore webhook prefs entirely
+            assertFalse(hasActiveAlertChannel(prefs))
+        }
+    }
+}


### PR DESCRIPTION
The main screen showed the green "Monitoring Active" status whenever monitoring was enabled with a scheduled alarm, recent activity, and permissions - it never checked whether any alert could actually be delivered. With no enabled SMS contact, no call contact, and no webhook, monitoring ran as a silent no-op behind a reassuring green status; the only cue was the greyed-out test button.

"Monitoring enabled but no usable alert channel" is now its own warning-colored state ("No Alert Recipient") with an explicit message. The check mirrors the alert pipeline: an enabled SMS contact with a number, a call contact, or (in webhook builds) an enabled+configured webhook. Enabling monitoring is still allowed so contacts can be set up afterwards.

New `hasActiveAlertChannel()` helper with unit tests; new strings translated for all 7 locales.

Fixes #187

Generated with [Claude Code](https://claude.com/claude-code)