### PR TITLE
Show exact alarm timing state as a Check Period subtitle

### DIFF
--- a/app/src/main/java/io/keepalive/android/SettingsActivity.kt
+++ b/app/src/main/java/io/keepalive/android/SettingsActivity.kt
@@ -254,6 +254,17 @@ class SettingsActivity : AppCompatActivity() {
         val timePeriodValueTextView: TextView = findViewById(R.id.edit_time_period_hours)
         timePeriodValueTextView.text = sharedPrefs!!.getString(PrefKeys.TIME_PERIOD_HOURS, "12")
 
+        // subtitle showing whether the check period uses exact or inexact alarm
+        //  timing; the toggle itself lives in this row's edit dialog
+        val exactAlarmStatusTextView: TextView = findViewById(R.id.edit_exact_alarm_status)
+        exactAlarmStatusTextView.text = getString(
+            if (sharedPrefs!!.getBoolean(PrefKeys.USE_EXACT_ALARMS, false)) {
+                R.string.exact_alarm_status_exact
+            } else {
+                R.string.exact_alarm_status_inexact
+            }
+        )
+
         val monitoredAppsValueTextView: TextView = findViewById(R.id.edit_monitored_apps)
         val appsToMonitor: MutableList<MonitoredAppDetails> = loadJSONSharedPreference(
             sharedPrefs!!,"APPS_TO_MONITOR")

--- a/app/src/main/res/layout/content_settings.xml
+++ b/app/src/main/res/layout/content_settings.xml
@@ -63,24 +63,39 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="@dimen/default_view_height"
+        android:orientation="vertical"
         android:background="?android:attr/selectableItemBackground"
         android:padding="8dp">
 
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_weight="1"
-            android:text="@string/time_period_title"
-            android:textSize="@dimen/default_text_size" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                android:text="@string/time_period_title"
+                android:textSize="@dimen/default_text_size" />
+
+            <TextView
+                android:id="@+id/edit_time_period_hours"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_weight="0.2"
+                android:gravity="end"
+                android:text="" />
+        </LinearLayout>
+
+        <!-- exact/inexact alarm timing, edited via the toggle in this row's dialog -->
         <TextView
-            android:id="@+id/edit_time_period_hours"
-            android:layout_width="0dp"
+            android:id="@+id/edit_exact_alarm_status"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_weight="0.2"
-            android:gravity="end"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="@dimen/subtitle_text_size"
             android:text="" />
     </LinearLayout>
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -173,6 +173,8 @@
     <string name="time_period_description">Anzahl der Stunden der Inaktivität, bevor eine \"Bist du noch da?\"-Benachrichtigung erscheint.</string>
     <string name="followup_time_period_title">Minuten bis zur Bestätigung warten</string>
     <string name="exact_alarm_toggle_title">Exakte Alarmzeit verwenden</string>
+    <string name="exact_alarm_status_exact">Exakte Alarmzeit: Aktiviert</string>
+    <string name="exact_alarm_status_inexact">Exakte Alarmzeit: Deaktiviert</string>
     <string name="exact_alarm_note">HINWEIS: Diese Zeitangabe ist nicht exakt und das System kann die Benachrichtigung um bis zu 1 Stunde verzögern.\n\nAktivieren Sie unten \"Exakte Alarmzeit verwenden\", wenn Sie präzise Überprüfungen benötigen. Dies kann den Akkuverbrauch leicht erhöhen.</string>
     <string name="rest_period_title">Ruhezeit</string>
     <string name="followup_time_period_description">Die Anzahl Minuten, die nach einer \"Sind Sie da?\"-Benachrichtigung gewartet wird, bevor ein Alarm an Ihre Notfallkontakte gesendet wird.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -173,6 +173,8 @@
     <string name="time_period_description">El número de horas de inactividad antes de que se te muestre una notificación \'¿Sigues ahí?\'.</string>
     <string name="followup_time_period_title">Minutos de espera para la confirmación</string>
     <string name="exact_alarm_toggle_title">Usar temporización exacta de alarmas</string>
+    <string name="exact_alarm_status_exact">Temporización exacta de alarmas: Activada</string>
+    <string name="exact_alarm_status_inexact">Temporización exacta de alarmas: Desactivada</string>
     <string name="exact_alarm_note">NOTA: Esta temporización no es exacta y el sistema puede retrasar esta notificación hasta 1 hora.\n\nActiva \'Usar temporización exacta de alarmas\' abajo si necesitas verificaciones precisas, lo que puede aumentar ligeramente el uso de la batería.</string>
     <string name="rest_period_title">Rango de tiempo del período de descanso</string>
     <string name="followup_time_period_description">El número de minutos a esperar después de enviar una notificación \'¿Sigues ahí?\' antes de que se envíe una alerta a tu(s) contacto(s) de emergencia</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -173,6 +173,8 @@
     <string name="time_period_description">Le nombre d\'heures d\'inactivité avant qu\'une notification «Êtes-vous là?» ne soit affichée.</string>
     <string name="followup_time_period_title">Minutes à attendre pour la confirmation</string>
     <string name="exact_alarm_toggle_title">Utiliser le minutage exact de l\'alarme</string>
+    <string name="exact_alarm_status_exact">Minutage exact de l\'alarme : Activé</string>
+    <string name="exact_alarm_status_inexact">Minutage exact de l\'alarme : Désactivé</string>
     <string name="exact_alarm_note">REMARQUE : Ce minutage n\'est pas exact et le système peut retarder cette notification jusqu\'à 1 heure.\n\nActivez «Utiliser le minutage exact de l\'alarme» ci-dessous si vous avez besoin de vérifications précises, ce qui peut légèrement augmenter l\'utilisation de la batterie.</string>
     <string name="rest_period_title">Plage de temps de la période de repos</string>
     <string name="followup_time_period_description">Le nombre de minutes à attendre après l\'envoi d\'une notification «Êtes-vous là?» avant qu\'une alerte ne soit envoyée à vos contacts d\'urgence</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -173,6 +173,8 @@
         <string name="time_period_description">Il numero di ore di inattività prima di ricevere una notifica "Ci sei?".\n\nNOTA: Questo ritardo non è esatto e il sistema potrebbe ritardare questa notifica fino a un\'ora.</string>  
         <string name="followup_time_period_title">Minuti di attesa per la conferma</string>  
         <string name="exact_alarm_toggle_title">Usa Temporizzazione Allarme Esatta</string>
+        <string name="exact_alarm_status_exact">Temporizzazione Allarme Esatta: Attivata</string>
+        <string name="exact_alarm_status_inexact">Temporizzazione Allarme Esatta: Disattivata</string>
         <string name="exact_alarm_note">NOTA: Questa temporizzazione non è esatta e il sistema potrebbe ritardare questa notifica fino a 1 ora.\n\nAbilita \'Usa Temporizzazione Allarme Esatta\' qui sotto se hai bisogno di controlli precisi, il che potrebbe aumentare leggermente il consumo della batteria.</string>
         <string name="rest_period_title">Intervallo di tempo del periodo di riposo</string>
         <string name="followup_time_period_description">Il numero di minuti da attendere dopo l\'invio di una notifica "Ci sei?" prima che un avviso venga inviato ai tuoi contatti di emergenza</string>  

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -173,6 +173,8 @@
     <string name="time_period_description">Liczba godzin bezczynności przed wyświetleniem powiadomienia \'Jesteś tam?\'</string>
     <string name="followup_time_period_title">Minuty oczekiwania na potwierdzenie</string>
     <string name="exact_alarm_toggle_title">Użyj dokładnego czasu alarmu</string>
+    <string name="exact_alarm_status_exact">Dokładny czas alarmu: Włączony</string>
+    <string name="exact_alarm_status_inexact">Dokładny czas alarmu: Wyłączony</string>
     <string name="exact_alarm_note">UWAGA: Ten czas nie jest dokładny, a system może opóźnić powiadomienie nawet o 1 godzinę.\n\nWłącz "Użyj dokładnego czasu alarmu" poniżej, jeśli potrzebujesz precyzyjnych kontroli — może to nieznacznie zwiększyć zużycie baterii.</string>
     <string name="rest_period_title">Zakres Czasu Odpoczynku</string>
     <string name="followup_time_period_description">Ile minut należy poczekać na odpowiedź do pytania \'Jesteś tam?\' zanim Alert wysłany zostanie do Twoich Kontaktów Alarmowych.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -173,6 +173,8 @@
     <string name="time_period_description">Количество часов бездействия перед появлением уведомления \'Вы здесь?\'</string>
     <string name="followup_time_period_title">Сколько минут ожидать подтверждения</string>
     <string name="exact_alarm_toggle_title">Использовать точное время сигнала</string>
+    <string name="exact_alarm_status_exact">Точное время сигнала: Включено</string>
+    <string name="exact_alarm_status_inexact">Точное время сигнала: Выключено</string>
     <string name="exact_alarm_note">ПРИМЕЧАНИЕ: Это время неточное, и система может задержать уведомление до 1 часа.\n\nВключите \'Использовать точное время сигнала\' ниже, если вам нужны точные проверки — это может немного увеличить расход батареи.</string>
     <string name="rest_period_title">Период отдыха</string>
     <string name="followup_time_period_description">Количество минут ожидания после отправки уведомления \'Вы здесь?\', прежде чем оповещение будет отправлено вашим контактам для экстренных случаев.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -173,6 +173,8 @@
     <string name="time_period_description">设备超过 # 小时不活动，系统将弹出 \'Are you there?\' 的通知。</string>
     <string name="followup_time_period_title">等待多久后发出提醒</string>
     <string name="exact_alarm_toggle_title">使用精确闹钟计时</string>
+    <string name="exact_alarm_status_exact">精确闹钟计时：已启用</string>
+    <string name="exact_alarm_status_inexact">精确闹钟计时：已禁用</string>
     <string name="exact_alarm_note">注意：此时间并非精确值，系统可能延迟最多1小时发送通知。\n\n若需精确检测，请启用下方的“使用精确闹钟计时”功能，可能略微增加电池电量消耗。</string>
     <string name="rest_period_title">休眠期</string>
     <string name="followup_time_period_description">弹出 \'Are you there?\' 的通知后，等待 # 分钟无人响应才会向您的联系人发出提醒。</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,6 +1,9 @@
 <resources>
     <dimen name="default_text_size">16sp</dimen>
 
+    <!-- secondary/subtitle text shown beneath a setting's title -->
+    <dimen name="subtitle_text_size">14sp</dimen>
+
     <!-- size set to 18 for some things so that the contrast requirement is lower when
           google play store does accessibility checks -->
     <dimen name="header_text_size">18sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,8 @@
     <string name="time_period_description">The # of hours of inactivity before you will be prompted with an \'Are you there?\' notification.</string>
     <string name="followup_time_period_title">Minutes to Wait for Confirmation</string>
     <string name="exact_alarm_toggle_title">Use Exact Alarm Timing</string>
+    <string name="exact_alarm_status_exact">Exact Alarm Timing: Enabled</string>
+    <string name="exact_alarm_status_inexact">Exact Alarm Timing: Disabled</string>
     <string name="exact_alarm_note">NOTE: This timing is not exact and the system may delay this notification by up to 1 hour.\n\nEnable \'Use Exact Alarm Timing\' below if you require precise checks, which may slightly increase battery usage.</string>
     <string name="rest_period_title">Rest Period Time Range</string>
     <string name="followup_time_period_description">The # of minutes to wait after sending a \'Are you there?\' notification before an Alert will be sent to your Emergency Contact(s)</string>


### PR DESCRIPTION
The Use Exact Alarm Timing toggle only lives inside the Check Period edit dialog, so once set there was no way to see the current state without reopening that dialog. Add an "Exact Alarm Timing: Enabled" / "Exact Alarm Timing: Disabled" subtitle to the Check Period row itself, which already opens that dialog on tap. Reflects only the setting; no permission state, since exact-alarm permission is required for the final alarm regardless.

Fixes #191