### PR TITLE
Route permanently denied runtime permissions to app settings

### DIFF
--- a/app/src/main/java/io/keepalive/android/MainActivity.kt
+++ b/app/src/main/java/io/keepalive/android/MainActivity.kt
@@ -176,9 +176,16 @@ class MainActivity : AppCompatActivity() {
             "requestCode: $requestCode, permissions: ${permissions.contentToString()}, grantResults: ${grantResults.contentToString()}"
         )
 
+        val permissionManager = PermissionManager(this, this)
+
+        // if a permission was permanently denied the system dialog won't appear
+        //  anymore, so route the user to the app's settings page instead of
+        //  silently no-op'ing the request
+        permissionManager.handlePermissionResult(permissions, grantResults)
+
         // don't really need to check whether the permissions were granted or not?
         //  just check all of the permissions and hide the button appropriately
-        adjustPermissionsComponents(PermissionManager(this, this).checkNeedAnyPermissions())
+        adjustPermissionsComponents(permissionManager.checkNeedAnyPermissions())
     }
 
     private fun updateMainContent(needPermissions: Boolean) {

--- a/app/src/main/java/io/keepalive/android/PermissionManager.kt
+++ b/app/src/main/java/io/keepalive/android/PermissionManager.kt
@@ -7,6 +7,7 @@ import android.app.AppOpsManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.util.Log
@@ -260,6 +261,49 @@ class PermissionManager(private val context: Context, private val activity: AppC
             .show()
     }
 
+    // Handle the result of a runtime permission request (call from the hosting
+    //  Activity's onRequestPermissionsResult). Once a permission is permanently
+    //  denied - "Don't allow" twice, or set to "Not allowed" in system settings -
+    //  requestPermissions() no longer shows the system dialog and silently
+    //  returns denied (the framework logs "No requestable permission in the
+    //  request."), so the explain-then-request path dead-ends. In that case send
+    //  the user to the app's settings page where they can re-enable it.
+    fun handlePermissionResult(permissions: Array<out String>, grantResults: IntArray) {
+        val act = activity ?: return
+        val permanentlyDenied = firstPermanentlyDeniedPermission(
+            permissions,
+            grantResults,
+            shouldShowRationale = { ActivityCompat.shouldShowRequestPermissionRationale(act, it) },
+            isKnown = { permissionExplanations.containsKey(it) }
+        ) ?: return
+
+        explainPermanentlyDeniedPermission(permanentlyDenied)
+    }
+
+    private fun explainPermanentlyDeniedPermission(permission: String) {
+        val title = permissionExplanations[permission]?.get(0) ?: return
+        Log.d(tag, "Permission $permission is permanently denied, routing to app settings")
+
+        AlertDialog.Builder(context, R.style.AlertDialogTheme)
+            .setTitle(title)
+            .setMessage(context.getString(R.string.permission_denied_go_to_settings_message))
+            .setPositiveButton(context.getString(R.string.go_to_settings)) { _, _ ->
+
+                // the system request dialog won't appear anymore, so open the
+                //  app's details page where the permission can be re-enabled
+                val intent = Intent(
+                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", context.packageName, null)
+                )
+                activity?.startActivity(intent) ?: run {
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    context.startActivity(intent)
+                }
+            }
+            .setNegativeButton(context.getString(R.string.cancel), null)
+            .show()
+    }
+
     private fun checkBackgroundLocationPermissions(requestPermissions: Boolean): Boolean {
 
         Log.d(tag, "Checking background location permissions")
@@ -418,4 +462,33 @@ class PermissionManager(private val context: Context, private val activity: AppC
             return true
         }
     }
+}
+
+/**
+ * The first requested permission that came back denied and can no longer be
+ * requested through the system dialog — i.e. permanently denied. In the result
+ * callback, "denied AND no rationale" is the permanent-denial signature: a
+ * first-time or soft-denied permission would have shown the system dialog
+ * (granting, or making [shouldShowRationale] true), so reaching the callback
+ * denied without rationale means requestPermissions() no-op'd and the user must
+ * go to settings. Returns null when nothing needs that handling (e.g. all
+ * granted, or an empty/cancelled result). [isKnown] limits handling to
+ * permissions we actually explain.
+ */
+internal fun firstPermanentlyDeniedPermission(
+    permissions: Array<out String>,
+    grantResults: IntArray,
+    shouldShowRationale: (String) -> Boolean,
+    isKnown: (String) -> Boolean
+): String? {
+    for (i in permissions.indices) {
+        if (i < grantResults.size &&
+            grantResults[i] == PackageManager.PERMISSION_DENIED &&
+            !shouldShowRationale(permissions[i]) &&
+            isKnown(permissions[i])
+        ) {
+            return permissions[i]
+        }
+    }
+    return null
 }

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -13,6 +13,7 @@
     <string name="confirm">Bestätigen</string>
     <string name="back">Zurück</string>
     <string name="go_to_settings">Einstellungen</string>
+    <string name="permission_denied_go_to_settings_message">Diese Berechtigung ist derzeit auf „Nicht zulässig" gesetzt und kann daher hier nicht angefragt werden. Bitte öffnen Sie die Einstellungen und erlauben Sie sie, damit Alarme gesendet werden können.</string>
     <string name="enabled">Aktiv</string>
 
     <!-- webhook layout strings -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -13,6 +13,7 @@
     <string name="confirm">Confirmar</string>
     <string name="back">Atrás</string>
     <string name="go_to_settings">Ir a Configuración</string>
+    <string name="permission_denied_go_to_settings_message">Este permiso está configurado actualmente como «No permitido», por lo que no se puede solicitar aquí. Abra Ajustes y concédalo para que se puedan enviar las alertas.</string>
     <string name="enabled">Activado</string>
 
     <!-- webhook layout strings -->

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -13,6 +13,7 @@
     <string name="confirm">Confirmer</string>
     <string name="back">Dos</string>
     <string name="go_to_settings">Paramètre</string>
+    <string name="permission_denied_go_to_settings_message">Cette autorisation est actuellement réglée sur « Non autorisé », elle ne peut donc pas être demandée ici. Veuillez ouvrir les Paramètres et l\'autoriser afin que les alertes puissent être envoyées.</string>
     <string name="enabled">Activé</string>
 
     <!-- webhook layout strings -->

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -13,6 +13,7 @@
       <string name="confirm">Conferma</string>  
       <string name="back">Indietro</string>  
       <string name="go_to_settings">Impostazioni</string>  
+      <string name="permission_denied_go_to_settings_message">Questa autorizzazione è attualmente impostata su «Non consentito», quindi non può essere richiesta qui. Apri le Impostazioni e concedila affinché gli avvisi possano essere inviati.</string>
       <string name="enabled">Attivato</string>  
       
       <!-- webhook layout strings -->  

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -13,6 +13,7 @@
     <string name="confirm">Potwierdź</string>
     <string name="back">Z powrotem</string>
     <string name="go_to_settings">Przejdź do Ustawień</string>
+    <string name="permission_denied_go_to_settings_message">To uprawnienie jest obecnie ustawione na „Nie zezwalaj", więc nie można go tu poprosić. Otwórz Ustawienia i zezwól na nie, aby alarmy mogły być wysyłane.</string>
     <string name="enabled">Aktywny</string>
 
     <!-- webhook layout strings -->

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -13,6 +13,7 @@
     <string name="confirm">Подтвердить</string>
     <string name="back">Назад</string>
     <string name="go_to_settings">В настройки</string>
+    <string name="permission_denied_go_to_settings_message">Это разрешение сейчас установлено на «Запрещено», поэтому его нельзя запросить здесь. Откройте настройки и предоставьте его, чтобы можно было отправлять оповещения.</string>
     <string name="enabled">Включено</string>
 
     <!-- webhook layout strings -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -13,6 +13,7 @@
     <string name="confirm">确认</string>
     <string name="back">后退</string>
     <string name="go_to_settings">去设置</string>
+    <string name="permission_denied_go_to_settings_message">此权限当前被设置为“不允许”，因此无法在此请求。请打开设置并授予该权限，以便能够发送警报。</string>
     <string name="enabled">启用</string>
 
     <!-- webhook layout strings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="confirm">Confirm</string>
     <string name="back">Back</string>
     <string name="go_to_settings">Go to Settings</string>
+    <string name="permission_denied_go_to_settings_message">This permission is currently set to \"Not allowed\", so it can\'t be requested here. Please open Settings and allow it so that alerts can be sent.</string>
     <string name="enabled">Enabled</string>
     <string name="placeholder" translatable="false">PLACEHOLDER TEXT</string>
 

--- a/app/src/test/java/io/keepalive/android/FirstPermanentlyDeniedPermissionTest.kt
+++ b/app/src/test/java/io/keepalive/android/FirstPermanentlyDeniedPermissionTest.kt
@@ -1,0 +1,71 @@
+package io.keepalive.android
+
+import android.content.pm.PackageManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins [firstPermanentlyDeniedPermission], the decision behind routing the user
+ * to app settings when a permission can no longer be requested (set to "Not
+ * allowed" in system settings / denied permanently). In that state
+ * requestPermissions() silently no-ops, so the OK button dead-ends; the callback
+ * must detect it via "denied AND no rationale" and open settings instead.
+ *
+ * Pure function — plain JUnit, no Robolectric needed.
+ */
+class FirstPermanentlyDeniedPermissionTest {
+
+    private val GRANTED = PackageManager.PERMISSION_GRANTED
+    private val DENIED = PackageManager.PERMISSION_DENIED
+
+    // default: every permission is "known" (has an explanation) and has no rationale
+    private fun decide(
+        permissions: Array<String>,
+        grantResults: IntArray,
+        rationale: Set<String> = emptySet(),
+        known: Set<String> = permissions.toSet()
+    ): String? = firstPermanentlyDeniedPermission(
+        permissions,
+        grantResults,
+        shouldShowRationale = { it in rationale },
+        isKnown = { it in known }
+    )
+
+    @Test fun `all granted returns null`() {
+        assertNull(decide(arrayOf("SEND_SMS"), intArrayOf(GRANTED)))
+    }
+
+    @Test fun `denied without rationale is permanently denied`() {
+        // the reported case: SEND_SMS set to Not allowed in system settings
+        assertEquals("SEND_SMS", decide(arrayOf("SEND_SMS"), intArrayOf(DENIED)))
+    }
+
+    @Test fun `denied but rationale still showable is not routed to settings`() {
+        // soft denial — the system dialog will still appear on the next request
+        assertNull(decide(arrayOf("SEND_SMS"), intArrayOf(DENIED), rationale = setOf("SEND_SMS")))
+    }
+
+    @Test fun `denied but unknown permission is ignored`() {
+        // a permission we don't have an explanation for is not our concern
+        assertNull(decide(arrayOf("com.other.PERM"), intArrayOf(DENIED), known = emptySet()))
+    }
+
+    @Test fun `returns the permanently denied one among a mixed result`() {
+        val result = decide(
+            arrayOf("POST_NOTIFICATIONS", "SEND_SMS"),
+            intArrayOf(GRANTED, DENIED)
+        )
+        assertEquals("SEND_SMS", result)
+    }
+
+    @Test fun `empty result is treated as a cancellation`() {
+        // Android delivers empty arrays when the interaction is interrupted
+        assertNull(decide(arrayOf(), intArrayOf()))
+    }
+
+    @Test fun `grantResults shorter than permissions does not crash`() {
+        // defensive: never index past grantResults
+        assertNull(decide(arrayOf("SEND_SMS"), intArrayOf()))
+    }
+}


### PR DESCRIPTION
**Symptom:** if a runtime permission (e.g. SEND_SMS) is set to "Not allowed" in the app's system settings, KeepAlive detects it's missing and shows the explanation dialog, but clicking OK does nothing. The log shows "No requestable permission in the request."

**Cause:** for runtime permissions, the OK button calls `ActivityCompat.requestPermissions()`. Once a permission is permanently denied ("Don't allow" twice, or set to "Not allowed" in settings), Android no longer shows the grant dialog — its permission-grant activity finds nothing requestable, logs that message, and finishes. So the request is a silent no-op. (Settings-based permissions like usage access and exact alarm avoid this because they open a settings screen instead.)

**Fix:** `onRequestPermissionsResult` now detects the permanent-denial signature — denied result with `shouldShowRequestPermissionRationale() == false`, for a permission we actually explain — and offers to open the app's details settings page (`ACTION_APPLICATION_DETAILS_SETTINGS`) where the user can re-enable it. Covers every runtime permission, not just SMS.

The decision is a pure helper (`firstPermanentlyDeniedPermission`) with unit tests covering: granted, permanently denied, soft-denied (rationale still showable — not routed), unknown permission, mixed results, and empty/short result arrays (cancellation).

Note: this complements the background SMS-permission notification on the `BackgroundPermissionCheck` branch — that notification opens the app, which is exactly where this dead-end was, so the two together make a revoked SMS permission both detectable and fixable.

One caveat worth an on-device check: the fix assumes `onRequestPermissionsResult` delivers the denied permission name in this state (rather than an empty array). Worth confirming on the device where you saw the "No requestable permission" log — if the arrays come back empty there, I'll switch to proactive detection before the request instead.

Generated with [Claude Code](https://claude.com/claude-code)