### PR TITLE
Simplify the main screen time displays

### DIFF
--- a/app/src/main/java/io/keepalive/android/MainActivity.kt
+++ b/app/src/main/java/io/keepalive/android/MainActivity.kt
@@ -530,12 +530,10 @@ class MainActivity : AppCompatActivity() {
                     } else {
                         Log.d(tag, "Don't need any permissions, we are all set?!")
 
-                        // get the hours and minutes so we can show the time until the next
-                        //  activity check in a friendly format
-                        val alarmTimestampInSec =
-                            (alarmTimestamp - System.currentTimeMillis()) / 1000
-                        val hours = alarmTimestampInSec / 3600
-                        val minutes = (alarmTimestampInSec % 3600) / 60
+                        // minutes until the next activity check, shown in a
+                        //  friendly format without a leading zero-hours unit
+                        val minutesUntilCheck =
+                            (alarmTimestamp - System.currentTimeMillis()) / 1000 / 60
 
                         // set a big green message indicating that monitoring is active
                         monitoringStatusTextView.text = getString(R.string.monitoring_active_title)
@@ -546,10 +544,8 @@ class MainActivity : AppCompatActivity() {
                         // set the message to show the last detected activity and when the next check is
                         monitoringMessageTextView.text = String.format(
                             getString(R.string.monitoring_active_message),
-                            getDateTimeStrFromTimestamp(
-                                lastInteractiveEvent.timeStamp,
-                                TimeZone.getDefault().id
-                            ), hours.toString(), minutes.toString()
+                            formatLastActivityTimestamp(this, lastInteractiveEvent.timeStamp),
+                            formatCountdown(this, minutesUntilCheck)
                         )
 
                         // check whether app restrictions are enabled and adjust the components based

--- a/app/src/main/java/io/keepalive/android/UtilityFunctions.kt
+++ b/app/src/main/java/io/keepalive/android/UtilityFunctions.kt
@@ -8,6 +8,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.SystemClock
 import android.os.UserManager
+import android.text.format.DateFormat
 import android.util.Log
 import androidx.annotation.ColorRes
 import androidx.preference.PreferenceManager
@@ -70,6 +71,37 @@ fun hasActiveAlertChannel(sharedPrefs: SharedPreferences): Boolean {
     }
 
     return false
+}
+
+// format the last-activity timestamp for the main screen: time only (no
+//  seconds) when it is today, date and time otherwise. the platform
+//  formatters handle the locale and the device's 12/24 hour setting (issue #189)
+fun formatLastActivityTimestamp(context: Context, timestamp: Long): String {
+    val date = Date(timestamp)
+    val timeStr = DateFormat.getTimeFormat(context).format(date)
+
+    val now = Calendar.getInstance()
+    val then = Calendar.getInstance().apply { timeInMillis = timestamp }
+    val isToday = now.get(Calendar.YEAR) == then.get(Calendar.YEAR) &&
+            now.get(Calendar.DAY_OF_YEAR) == then.get(Calendar.DAY_OF_YEAR)
+
+    return if (isToday) {
+        timeStr
+    } else {
+        "${DateFormat.getDateFormat(context).format(date)} $timeStr"
+    }
+}
+
+// format the time until the next activity check without a leading zero-hours
+//  unit: "57 min" rather than "0 hours and 57 minutes" (issue #189)
+fun formatCountdown(context: Context, totalMinutes: Long): String {
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    return if (hours > 0) {
+        context.getString(R.string.countdown_format_hours_minutes, hours.toString(), minutes.toString())
+    } else {
+        context.getString(R.string.countdown_format_minutes, minutes.toString())
+    }
 }
 
 // load a JSON string from shared preferences and convert it to a list of objects

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -79,7 +79,9 @@
     <string name="hibernation_dialog_message_api_backport"><![CDATA[Android entfernt jetzt automatisch die Berechtigungen für Apps, die in letzter Zeit nicht verwendet wurden.  Sobald die Einstellungen konfiguriert sind, benötigt Keep Alive keine weitere Interaktion, es sei denn, ein Alarm wird ausgelöst.<br/><br/>Um sicherzustellen, dass die Berechtigungen nicht entzogen werden, deaktivieren Sie bitte die Option <b>Berechtigungen entfernen, wenn die App nicht verwendet wird</b>.]]></string>
 
     <!-- MainActivity textview and button messages -->
-    <string name="monitoring_active_message">Letzte Aktivität erkannt um: %1$s\nNächster Aktivitäts-Check in: %2$s Stunden und %3$s Minuten</string>
+    <string name="monitoring_active_message">Letzte Aktivität erkannt um: %1$s\nNächster Aktivitäts-Check in: %2$s</string>
+    <string name="countdown_format_hours_minutes">%1$s Std. %2$s Min.</string>
+    <string name="countdown_format_minutes">%1$s Min.</string>
     <string name="monitoring_active_title">Überwachung aktiv</string>
     <string name="monitoring_impaired_title">Überwachung aktiv,\n aber evtl. beeinträchtigt</string>
     <string name="monitoring_inactive_message">Überwachung ist nicht aktiv.\nSchaltfläche drücken, um sie wieder zu starten.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,7 +79,9 @@
     <string name="hibernation_dialog_message_api_backport"><![CDATA[Android ahora elimina automáticamente los permisos de las apps que no se han usado recientemente. Keep Alive, una vez configurado, no necesita ninguna interacción adicional a menos que se active una alerta.<br/><br/>Para asegurarte de que los permisos no se revoquen, desactiva la opción <b>\'Quitar permisos si no se usa la app\'</b>.]]></string>
 
     <!-- MainActivity textview and button messages -->
-    <string name="monitoring_active_message">Última actividad detectada a las: %1$s\nPróxima verificación de actividad en: %2$s horas y %3$s minutos</string>
+    <string name="monitoring_active_message">Última actividad detectada a las: %1$s\nPróxima verificación de actividad en: %2$s</string>
+    <string name="countdown_format_hours_minutes">%1$s h %2$s min</string>
+    <string name="countdown_format_minutes">%1$s min</string>
     <string name="monitoring_active_title">Monitoreo activo</string>
     <string name="monitoring_impaired_title">Monitoreo activo\nPero podría estar afectado</string>
     <string name="monitoring_inactive_message">El monitoreo no está activo.\nToca el botón para reiniciarlo.</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -79,7 +79,9 @@
     <string name="hibernation_dialog_message_api_backport"><![CDATA[Android supprime désormais automatiquement les autorisations pour les applications qui n\'ont pas été utilisées récemment. Keep Alive, une fois les paramètres configurés, ne nécessite aucune autre interaction à moins qu\'une alerte ne soit déclenchée.<br/><br/>Pour garantir que les autorisations ne sont pas révoquées, veuillez désactiver l\'option <b>Supprimer les autorisations si l\'appli n\'est pas utilisée</b>.]]></string>
 
     <!-- MainActivity textview and button messages -->
-    <string name="monitoring_active_message">Dernière activité détectée à: %1$s\nProchain enregistrement d\'activité: %2$s heures et %3$s minutes</string>
+    <string name="monitoring_active_message">Dernière activité détectée à: %1$s\nProchain enregistrement d\'activité: %2$s</string>
+    <string name="countdown_format_hours_minutes">%1$s h %2$s min</string>
+    <string name="countdown_format_minutes">%1$s min</string>
     <string name="monitoring_active_title">Surveillance active</string>
     <string name="monitoring_impaired_title">Surveillance active\nMais peut être altérée</string>
     <string name="monitoring_inactive_message">La surveillance n\'est pas active.\nCliquez sur le bouton pour la redémarrer.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -79,7 +79,9 @@
         <string name="hibernation_dialog_message_api_backport"><![CDATA[Android ora rimuove automaticamente le autorizzazioni per le app che non sono state utilizzate di recente. Keep Alive, una volta configurato, non richiede ulteriori interazioni a meno che non venga attivato un avviso.<br/><br/>Per garantire che le autorizzazioni non vengano revocate, disattivare l\'opzione <b>Rimuovi le autorizzazioni se l\'app non viene utilizzata</b>.]]></string>  
       
         <!-- MainActivity textview and button messages -->  
-        <string name="monitoring_active_message">Ultima attività rilevata a: %1$s\nProssima registrazione attività: %2$s ore e %3$s minuti</string>  
+        <string name="monitoring_active_message">Ultima attività rilevata a: %1$s\nProssima registrazione attività: %2$s</string>
+        <string name="countdown_format_hours_minutes">%1$s h %2$s min</string>
+        <string name="countdown_format_minutes">%1$s min</string>
         <string name="monitoring_active_title">Monitoraggio attivo</string>  
         <string name="monitoring_impaired_title">Monitoraggio attivo\nMa potrebbe essere compromesso</string>  
         <string name="monitoring_inactive_message">Il monitoraggio non è attivo.\nFare clic sul pulsante per riavviarlo.</string>  

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -79,7 +79,9 @@
     <string name="hibernation_dialog_message_api_backport"><![CDATA[Android automatycznie usuwa uprawnienia aplikacji, które nie były ostatnio używane.  Aplikacja Keep Alive nie potrzebuje żadnej interakcji po jej pierwszej konfiguracji i może przez to stracić uprawnienia.<br/><br/>Żeby mieć pewność, że Keep Alive może działać poprawnie wyłącz opcje <b>Usuń uprawnienia, jeśli aplikacja jest nieużywana</b>.]]></string>
 
     <!-- MainActivity textview and button messages -->
-    <string name="monitoring_active_message">Ostatnia wykryta aktywność: %1$s\nNastępne sprawdzenie za: %2$s godzin %3$s minut</string>
+    <string name="monitoring_active_message">Ostatnia wykryta aktywność: %1$s\nNastępne sprawdzenie za: %2$s</string>
+    <string name="countdown_format_hours_minutes">%1$s godz. %2$s min</string>
+    <string name="countdown_format_minutes">%1$s min</string>
     <string name="monitoring_active_title">Monitorowanie Aktywne</string>
     <string name="monitoring_impaired_title">Monitorowanie Aktywne\nAle może być zakłócone</string>
     <string name="monitoring_inactive_message">Monitorowanie nie jest aktywne.\nKliknij przycisk aby je ponownie uruchomić.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -79,7 +79,9 @@
     <string name="hibernation_dialog_message_api_backport"><![CDATA[Android теперь автоматически удаляет разрешения для приложений, которые в последнее время не использовались. Keep Alive после настройки параметров не требует какого-либо дальнейшего взаимодействия, если только не сработает оповещение.<br/><br/>Чтобы гарантировать, что разрешения не будут отозваны, отключите опцию <b>Отзывать разрешения, если приложение не используется</b>.]]></string>
 
     <!-- MainActivity textview and button messages -->
-    <string name="monitoring_active_message">Последняя активность обнаружена: %1$s\nСледующая проверка активности: %2$s часов and %3$s минут</string>
+    <string name="monitoring_active_message">Последняя активность обнаружена: %1$s\nСледующая проверка активности: %2$s</string>
+    <string name="countdown_format_hours_minutes">%1$s ч %2$s мин</string>
+    <string name="countdown_format_minutes">%1$s мин</string>
     <string name="monitoring_active_title">Мониторинг активен</string>
     <string name="monitoring_impaired_title">Мониторинг активен\nНо может работать некорректно</string>
     <string name="monitoring_inactive_message">Мониторинг неактивен.\nНажмите на кнопку для перезапуска.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,7 +79,9 @@
     <string name="hibernation_dialog_message_api_backport"><![CDATA[Android会自动清除长期未使用App的隐私权限。  KeepAlive一旦设置完成，除非触发提醒，否则无需任何进一步的交互操作。<br/><br/>为了确保权限不被撤销， 请禁用 <b>如果未使用此应用，则移除相关权限</b> 的选项。]]></string>
 
     <!-- MainActivity textview and button messages -->
-    <string name="monitoring_active_message">上一次活动: %1$s\n下一次检测: %2$s小时%3$s分钟后</string>
+    <string name="monitoring_active_message">上一次活动: %1$s\n下一次检测: %2$s后</string>
+    <string name="countdown_format_hours_minutes">%1$s小时%2$s分钟</string>
+    <string name="countdown_format_minutes">%1$s分钟</string>
     <string name="monitoring_active_title">监测器正常运行</string>
     <string name="monitoring_impaired_title">监测器正在运行\n但受损</string>
     <string name="monitoring_inactive_message">监测器已停止。\n点击按钮重新启动。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,7 +91,9 @@
     <string name="hibernation_dialog_message_api_backport"><![CDATA[Android now automatically removes permissions for Apps that have not been used recently.  Keep Alive, once the settings are configured, does not need any further interaction unless an Alert is triggered.<br/><br/>To ensure that permissions are not revoked, please disable the <b>\'Remove permissions if app isn\'t used\'</b> option.]]></string>
 
     <!-- MainActivity textview and button messages -->
-    <string name="monitoring_active_message">Last activity detected at: %1$s\nNext activity check in: %2$s hours and %3$s minutes</string>
+    <string name="monitoring_active_message">Last activity detected at: %1$s\nNext activity check in: %2$s</string>
+    <string name="countdown_format_hours_minutes">%1$s h %2$s min</string>
+    <string name="countdown_format_minutes">%1$s min</string>
     <string name="monitoring_active_title">Monitoring Active</string>
     <string name="monitoring_impaired_title">Monitoring Active\nBut May Be Impaired</string>
     <string name="monitoring_inactive_message">Monitoring is not active.\nClick the button to restart it.</string>

--- a/app/src/test/java/io/keepalive/android/MainScreenTimeFormatTest.kt
+++ b/app/src/test/java/io/keepalive/android/MainScreenTimeFormatTest.kt
@@ -1,0 +1,77 @@
+package io.keepalive.android
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+
+/**
+ * Pins [formatCountdown] and [formatLastActivityTimestamp], the main-screen
+ * time displays simplified in issue #189: no leading zero-hours unit on the
+ * countdown, and no date or seconds on a same-day last-activity timestamp.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MainScreenTimeFormatTest {
+
+    private val ctx: Context = ApplicationProvider.getApplicationContext()
+
+    // --- countdown ---
+
+    @Test fun `countdown under an hour drops the hours unit`() {
+        // the reported case: "0 hours and 57 minutes" -> "57 min"
+        assertEquals("57 min", formatCountdown(ctx, 57))
+    }
+
+    @Test fun `countdown with hours shows both units`() {
+        assertEquals("1 h 12 min", formatCountdown(ctx, 72))
+    }
+
+    @Test fun `countdown of exactly one hour shows zero minutes`() {
+        assertEquals("1 h 0 min", formatCountdown(ctx, 60))
+    }
+
+    @Test fun `countdown under a minute shows zero minutes`() {
+        assertEquals("0 min", formatCountdown(ctx, 0))
+    }
+
+    @Test fun `countdown with many hours does not roll over`() {
+        assertEquals("26 h 30 min", formatCountdown(ctx, 26 * 60 + 30))
+    }
+
+    // --- last activity timestamp ---
+
+    private fun todayAt(hour: Int, minute: Int): Long = Calendar.getInstance().apply {
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, minute)
+        set(Calendar.SECOND, 42)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+
+    @Test fun `timestamp from today shows time without date or seconds`() {
+        val formatted = formatLastActivityTimestamp(ctx, todayAt(7, 34))
+
+        // no date parts: no year, and short enough to be a bare time
+        val year = Calendar.getInstance().get(Calendar.YEAR).toString()
+        assertFalse("should not contain the year: $formatted", formatted.contains(year))
+        // no seconds: a bare time has exactly one ':' (e.g. "7:34 AM" or "07:34")
+        assertEquals("should have no seconds: $formatted", 1, formatted.count { it == ':' })
+        assertFalse("should not contain seconds value: $formatted", formatted.contains("42"))
+    }
+
+    @Test fun `timestamp from another day includes the date`() {
+        val lastWeek = todayAt(7, 34) - 7 * 24 * 60 * 60 * 1000L
+        val formatted = formatLastActivityTimestamp(ctx, lastWeek)
+        val todayFormatted = formatLastActivityTimestamp(ctx, todayAt(7, 34))
+
+        // the dated version must carry more than the bare time does
+        assertNotEquals(todayFormatted, formatted)
+        assertTrue("dated version should be longer: '$formatted' vs '$todayFormatted'",
+            formatted.length > todayFormatted.length)
+    }
+}


### PR DESCRIPTION
Implements both formatting changes from #189.

**Last activity:** was a full timestamp with seconds (`2026-07-03 07:34:35`). Now shows the localized time only when the activity was today, adding the date only for other days. Uses the platform formatters (`DateFormat.getTimeFormat()` / `getDateFormat()`), so the locale and the device's 12/24-hour setting are respected and seconds never appear.

**Next check countdown:** was always "X hours and Y minutes", including a zero hours unit ("0 hours and 57 minutes"). Now drops the leading zero unit: "57 min", or "1 h 12 min" when hours are non-zero. Unit abbreviations are per-locale string resources (`Std./Min.` for German, `godz./min` for Polish, `ч/мин` for Russian, `小时/分钟` for Chinese, etc.), per the issue's note that formatting should stay locale-aware and resource-driven.

`monitoring_active_message` now takes the pre-formatted countdown as a single argument; each locale's lead phrasing is preserved. This incidentally fixes the Russian string's untranslated "and" and keeps Chinese's trailing 后 construction intact.

Implementation notes: the formatting lives in two small helpers in UtilityFunctions covered by a new Robolectric test. The same-day check is done explicitly with Calendar rather than `DateUtils.isToday()`/`formatDateTime()`, which turned out to behave inconsistently (the flags-based API rendered a date for today under test).

Full unit suite passes; `LocaleStringParityTest` confirms format-token parity across all 8 locales.

Fixes #189