### PR TITLE
Add GitHub badge and publish the release signing fingerprint (README + keep-alive.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ height="80">](https://play.google.com/store/apps/details?id=io.keepalive.android
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
      alt="Get it on F-Droid"
      height="80">](https://f-droid.org/packages/io.keepalive.android/)
+[<img src="assets/get-it-on-github.svg"
+     alt="Get it on GitHub"
+     height="80">](https://github.com/keepalivedev/KeepAlive/releases)
 
 There is also a 'Lite' version available for F-Droid that removes the Internet permission and Webhook functionality. 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ There is also a 'Lite' version available for F-Droid that removes the Internet p
 alt="Get it on F-Droid (Lite)"
 height="80">](https://f-droid.org/packages/io.keepalive.lite.android/)
 
+### Verifying GitHub releases
+
+All APKs published on the [Releases](https://github.com/keepalivedev/KeepAlive/releases) page (including the Lite variant) are signed with the same certificate. To verify a downloaded APK before installing it:
+
+```
+apksigner verify --print-certs KeepAlive.apk
+```
+
+The certificate SHA-256 digest should be:
+
+```
+c45567b712d6fd7979df14f66f8a5c25859ee223e1f07e915a7eee201c14baef
+```
+
+Note that builds installed from an app store may be signed differently (for example by Google's Play App Signing); the digest above applies to the APKs from the GitHub Releases page.
+
 Available Translations: Chinese (CN), French (CA), German (DE), Italian (IT), Polish (PL), Russian (RU), Spanish (ES) <br/>
 Supports Android 5.1 (API 22) and up
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ c45567b712d6fd7979df14f66f8a5c25859ee223e1f07e915a7eee201c14baef
 
 Note that builds installed from an app store may be signed differently (for example by Google's Play App Signing); the digest above applies to the APKs from the GitHub Releases page.
 
+The same fingerprint is also published at [keep-alive.io](https://keep-alive.io/#verify).
+
 Available Translations: Chinese (CN), French (CA), German (DE), Italian (IT), Polish (PL), Russian (RU), Spanish (ES) <br/>
 Supports Android 5.1 (API 22) and up
 

--- a/assets/get-it-on-github.svg
+++ b/assets/get-it-on-github.svg
@@ -1,11 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="216" height="80" viewBox="0 0 216 80" role="img" aria-label="Get it on GitHub">
+<svg xmlns="http://www.w3.org/2000/svg" width="190" height="80" viewBox="0 0 190 80" role="img" aria-label="Get it on GitHub">
   <!-- Self-hosted "Get it on GitHub" badge, styled to sit alongside the
-       Google Play and F-Droid store badges in the README. The GitHub mark
-       is used here to link to this project's GitHub Releases page. -->
-  <rect x="1.5" y="1.5" width="213" height="77" rx="12" fill="#0d1117" stroke="#f0f6fc" stroke-width="2"/>
-  <g transform="translate(16,20) scale(2.5)" fill="#f0f6fc">
+       Google Play and F-Droid store badges in the README. Like those badge
+       images, the canvas includes transparent padding so the visible box
+       matches theirs at the same rendered height. The GitHub mark is used
+       here to link to this project's GitHub Releases page. -->
+  <rect x="13" y="11" width="164" height="58" rx="9" fill="#0d1117" stroke="#f0f6fc" stroke-width="1.5"/>
+  <g transform="translate(24,24) scale(2)" fill="#f0f6fc">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
   </g>
-  <text x="68" y="33" fill="#f0f6fc" font-family="Helvetica, Arial, sans-serif" font-size="14" letter-spacing="1.5">GET IT ON</text>
-  <text x="68" y="62" fill="#f0f6fc" font-family="Helvetica, Arial, sans-serif" font-size="28" font-weight="bold">GitHub</text>
+  <text x="64" y="35" fill="#f0f6fc" font-family="Helvetica, Arial, sans-serif" font-size="11" letter-spacing="1.2">GET IT ON</text>
+  <text x="64" y="58" fill="#f0f6fc" font-family="Helvetica, Arial, sans-serif" font-size="22" font-weight="bold">GitHub</text>
 </svg>

--- a/assets/get-it-on-github.svg
+++ b/assets/get-it-on-github.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="216" height="80" viewBox="0 0 216 80" role="img" aria-label="Get it on GitHub">
+  <!-- Self-hosted "Get it on GitHub" badge, styled to sit alongside the
+       Google Play and F-Droid store badges in the README. The GitHub mark
+       is used here to link to this project's GitHub Releases page. -->
+  <rect x="1.5" y="1.5" width="213" height="77" rx="12" fill="#0d1117" stroke="#f0f6fc" stroke-width="2"/>
+  <g transform="translate(16,20) scale(2.5)" fill="#f0f6fc">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+  </g>
+  <text x="68" y="33" fill="#f0f6fc" font-family="Helvetica, Arial, sans-serif" font-size="14" letter-spacing="1.5">GET IT ON</text>
+  <text x="68" y="62" fill="#f0f6fc" font-family="Helvetica, Arial, sans-serif" font-size="28" font-weight="bold">GitHub</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,14 @@
             border-radius: 5px;
             cursor: pointer;
         }
+        pre {
+            background-color: #2c2c2c; /* Dark gray */
+            color: #f5f5f5; /* Offwhite */
+            padding: 10px;
+            border-radius: 5px;
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+        }
     </style>
 </head>
 <body>
@@ -123,6 +131,15 @@
                 <p>Place a phone call with speakerphone enabled</p>
             </div>
         </div>
+    </div>
+    <br/><br/>
+    <div id="verify" style="text-align: center; max-width: 700px; margin: auto; padding: 0 10px;">
+        <h2>Verifying Downloaded APKs</h2>
+        <p>All APKs published on the <a href="https://github.com/keepalivedev/KeepAlive/releases" target="_blank">GitHub Releases page</a> (including the Lite variant) are signed with the same certificate. To verify a download before installing it:</p>
+        <pre>apksigner verify --print-certs KeepAlive.apk</pre>
+        <p>The certificate SHA-256 digest should be:</p>
+        <pre>c45567b712d6fd7979df14f66f8a5c25859ee223e1f07e915a7eee201c14baef</pre>
+        <p>Builds installed from an app store may be signed differently (for example by Google's Play App Signing); this digest applies to the APKs from GitHub Releases.</p>
     </div>
     <br/><br/>
     <div class="footer">


### PR DESCRIPTION
Closes #199 and the related request from #186.

**Badge:** signed APKs are published via GitHub Releases, but the README only badged Google Play and F-Droid. Adds a small self-hosted SVG badge (`assets/get-it-on-github.svg`) styled to sit alongside the store badges, linking to the Releases page - no third-party hotlink.

**Signing fingerprint, in both places:** a "Verifying GitHub releases" section in the README and a matching "Verifying Downloaded APKs" section on keep-alive.io (the site is served from this repo's main branch via GitHub Pages, so this merge publishes both). The sections cross-reference the same certificate SHA-256 digest:

```
c45567b712d6fd7979df14f66f8a5c25859ee223e1f07e915a7eee201c14baef
```

Verification performed: `apksigner verify --print-certs` against the local release builds of all three flavors (googlePlay, fDroid, fDroidLite - all signed with the same `CN=Keep Alive Dev` certificate) **and** against an APK downloaded from the GitHub Releases page. All match.

Scoping note kept in both texts: store-installed builds may be signed differently (e.g. Play App Signing); the digest applies to the GitHub Releases channel.

One honest caveat for #186's "not on the same platform as the code" ideal: keep-alive.io is GitHub Pages served from this same repo, so the site copy is corroboration and convenience, not an independent anchor. True independence would require hosting the anchor off-GitHub.

Fixes #199