### PR TITLE
Show the Are you there? prompt over the lock screen via full-screen intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,14 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
+    <!-- lets the "Are you there?" notification launch a full-screen activity over
+         the lock screen (the same mechanism alarm clocks use). granted at install
+         on sideloaded/F-Droid builds; on Android 14+ the Play Store revokes the
+         default grant unless the app has an approved calling/alarm core function,
+         in which case the user is sent to the Full Screen special access page
+         (see PermissionManager) -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="PackageVisibilityPolicy,QueryAllPackagesPermission" />
 
@@ -78,6 +86,23 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="io.keepalive.android.MainActivity" />
         </activity>
+
+        <!-- launched by the system via the "Are you there?" notification's
+             full-screen intent when the device is locked or the screen is off.
+             showWhenLocked/turnScreenOn attributes are API 27+; the activity
+             sets the equivalent window flags in code for older versions.
+             directBootAware so the prompt can also be shown for checks that
+             fire before the first unlock after a reboot -->
+        <activity
+            android:name="io.keepalive.android.AreYouThereActivity"
+            android:directBootAware="true"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:launchMode="singleInstance"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
+            android:theme="@style/Theme.KeepAlive.NoActionBar"
+            tools:targetApi="o_mr1" />
 
         <service
             android:name="io.keepalive.android.AlertService"

--- a/app/src/main/java/io/keepalive/android/AcknowledgeAreYouThere.kt
+++ b/app/src/main/java/io/keepalive/android/AcknowledgeAreYouThere.kt
@@ -19,6 +19,10 @@ object AcknowledgeAreYouThere {
         // If we showed the over-other-apps overlay, remove it.
         AreYouThereOverlay.dismiss(context)
 
+        // If the full-screen prompt activity is showing (launched over the lock
+        //  screen via the notification's full-screen intent), close it too.
+        AreYouThereActivity.finishActive()
+
         // Clear the Direct Boot notification flag in case it's still set, and
         // record the acknowledgement as activity in device-protected storage.
         // The timestamp lets the Direct Boot final-alarm branch of

--- a/app/src/main/java/io/keepalive/android/AlertService.kt
+++ b/app/src/main/java/io/keepalive/android/AlertService.kt
@@ -317,7 +317,13 @@ class AlertService : Service() {
                     AppController.ARE_YOU_THERE_NOTIFICATION_ID
                 )
             }
-            override fun dismissAreYouThereOverlay() = AreYouThereOverlay.dismiss(context)
+            override fun dismissAreYouThereOverlay() {
+                AreYouThereOverlay.dismiss(context)
+
+                // also close the full-screen prompt activity if it is showing —
+                //  the alert is firing so the prompt is no longer actionable
+                AreYouThereActivity.finishActive()
+            }
             override fun sendSmsAlert() = alertSender.sendAlertMessage()
             override fun makeCall() = makeAlertCall(context)
             override fun writeLastAlertAt(timestamp: Long) {

--- a/app/src/main/java/io/keepalive/android/AreYouThereActivity.kt
+++ b/app/src/main/java/io/keepalive/android/AreYouThereActivity.kt
@@ -1,0 +1,134 @@
+package io.keepalive.android
+
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.WindowManager
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import java.lang.ref.WeakReference
+
+/**
+ * Full-screen "Are you there?" prompt for the locked / screen-off case.
+ *
+ * Launched by the system via the notification's full-screen intent (see
+ * [AlertNotificationHelper]) — the same mechanism alarm clocks and incoming
+ * calls use. App overlay windows are layered *below* the keyguard, so the
+ * [AreYouThereOverlay] is invisible while the device is locked (issue #182);
+ * an activity with showWhenLocked is the only supported way to draw over it.
+ * The keyguard itself stays in place — this is drawn on top of it, and
+ * tapping "I'm OK" counts as presence without requiring an unlock, exactly
+ * like dismissing an alarm clock.
+ *
+ * Uses the same layout as the overlay so the two surfaces look identical.
+ */
+class AreYouThereActivity : AppCompatActivity() {
+
+    companion object {
+        const val EXTRA_MESSAGE = "AreYouThereMessage"
+
+        private const val TAG = "AreYouThereActivity"
+
+        // the currently-showing instance, if any. weak so a finished activity
+        //  can't leak; only used to close the prompt when it is acknowledged
+        //  elsewhere or the final alert fires
+        private var active: WeakReference<AreYouThereActivity>? = null
+
+        /** Close the prompt if it is showing. Safe to call from any thread. */
+        fun finishActive() {
+            Handler(Looper.getMainLooper()).post {
+                active?.get()?.takeIf { !it.isFinishing }?.let {
+                    Log.d(TAG, "Closing active full-screen prompt")
+                    it.finish()
+                }
+            }
+        }
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var countdownRunnable: Runnable? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // show over the keyguard and turn the screen on. the manifest attributes
+        //  cover API 27+; these calls make the intent explicit and the window
+        //  flags cover API < 27
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        } else {
+            @Suppress("DEPRECATION")
+            window.addFlags(
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+            )
+        }
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        // same layout as the over-other-apps overlay so the two surfaces match
+        setContentView(R.layout.overlay_are_you_there)
+
+        findViewById<TextView>(R.id.textAreYouThereTitle).text =
+            getString(R.string.initial_check_notification_title)
+
+        intent.getStringExtra(EXTRA_MESSAGE)?.takeIf { it.isNotBlank() }?.let {
+            findViewById<TextView>(R.id.textAreYouThereMessage).text = it
+        }
+
+        findViewById<Button>(R.id.buttonImOk).setOnClickListener {
+            DebugLogger.d(TAG, getString(R.string.debug_log_full_screen_prompt_acknowledged))
+
+            // cancels the notification, resets monitoring, and (via
+            //  finishActive) would close this activity — finish directly anyway
+            AcknowledgeAreYouThere.acknowledge(applicationContext)
+            finish()
+        }
+
+        active = WeakReference(this)
+
+        DebugLogger.d(TAG, getString(R.string.debug_log_full_screen_prompt_shown))
+
+        startCountdown()
+    }
+
+    // count down to the final alarm's actual scheduled time. when it is reached
+    //  the alert fires and this prompt is no longer actionable, so close it
+    //  (the alert pipeline also calls finishActive() as a belt-and-braces)
+    private fun startCountdown() {
+        val countdownText = findViewById<TextView>(R.id.textAreYouThereCountdown)
+        val alarmTimestamp = getAppSharedPreferences(this)
+            .getLong(PrefKeys.NEXT_ALARM_TIMESTAMP, 0L)
+
+        val runnable = object : Runnable {
+            override fun run() {
+                val remainingMs = alarmTimestamp - System.currentTimeMillis()
+                if (alarmTimestamp <= 0L || remainingMs <= 0) {
+                    finish()
+                    return
+                }
+                val totalSeconds = remainingMs / 1000
+                countdownText.text = getString(
+                    R.string.overlay_countdown_format,
+                    totalSeconds / 60,
+                    totalSeconds % 60
+                )
+                mainHandler.postDelayed(this, 1000L)
+            }
+        }
+        countdownRunnable = runnable
+        mainHandler.post(runnable)
+    }
+
+    override fun onDestroy() {
+        countdownRunnable?.let { mainHandler.removeCallbacks(it) }
+        countdownRunnable = null
+        if (active?.get() === this) {
+            active = null
+        }
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/io/keepalive/android/NotificationHelper.kt
+++ b/app/src/main/java/io/keepalive/android/NotificationHelper.kt
@@ -135,6 +135,16 @@ class AlertNotificationHelper(private val context: Context) {
         return false
     }
 
+    // the USE_FULL_SCREEN_INTENT special access only exists from API 34; below
+    //  that the manifest permission is granted at install
+    private fun canUseFullScreenIntent(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            notificationManager.canUseFullScreenIntent()
+        } else {
+            true
+        }
+    }
+
     fun cancelNotification(notificationId: Int) {
         notificationManager.cancel(notificationId)
     }
@@ -243,6 +253,41 @@ class AlertNotificationHelper(private val context: Context) {
                 // Don't auto dismiss just because they tapped the notification.
                 // We cancel it explicitly on acknowledgement.
                 builder.setAutoCancel(false)
+
+                // Full-screen intent: when the device is locked or the screen is
+                //  off, the system launches AreYouThereActivity over the keyguard
+                //  instead of only posting the notification. While the device is
+                //  actively in use this degrades to a heads-up notification and
+                //  the window overlay covers the full-screen role instead.
+                //  Gated on the same setting as the overlay and, on API 34+, on
+                //  the Full Screen special access — the Play Store revokes the
+                //  default grant at install for apps without an approved
+                //  calling/alarm core function (issue #182).
+                try {
+                    val fullScreenEnabled = getAppSharedPreferences(context)
+                        .getBoolean(PrefKeys.ARE_YOU_THERE_OVERLAY_ENABLED, true)
+
+                    if (fullScreenEnabled && canUseFullScreenIntent()) {
+                        val fullScreenIntent = Intent(context, AreYouThereActivity::class.java).apply {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            putExtra(AreYouThereActivity.EXTRA_MESSAGE, content)
+                        }
+                        val fullScreenPendingIntent = PendingIntent.getActivity(
+                            context,
+                            1,
+                            fullScreenIntent,
+                            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                        )
+                        builder.setFullScreenIntent(fullScreenPendingIntent, true)
+                        Log.d("sendNotification", "Full-screen intent attached")
+                    } else {
+                        Log.d("sendNotification", "Full-screen intent not attached " +
+                                "(enabled=$fullScreenEnabled, canUse=${canUseFullScreenIntent()})")
+                    }
+                } catch (e: Exception) {
+                    // the notification itself must still go out
+                    Log.w("sendNotification", "Failed to attach full-screen intent", e)
+                }
 
             } else {
                 // auto close the notification when it is touched

--- a/app/src/main/java/io/keepalive/android/PermissionManager.kt
+++ b/app/src/main/java/io/keepalive/android/PermissionManager.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.AlarmManager
 import androidx.appcompat.app.AlertDialog
 import android.app.AppOpsManager
+import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -125,6 +126,17 @@ class PermissionManager(private val context: Context, private val activity: AppC
                 context.getString(R.string.permission_schedule_alarms_description)
             )
         }
+
+        // full-screen intent special access added in API 34. the Play Store
+        //  revokes the default grant at install for apps without an approved
+        //  calling/alarm core function, so the user may need to enable it
+        //  manually; sideloaded/F-Droid installs keep the default grant
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            permissionExplanations[Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT] = arrayOf(
+                context.getString(R.string.permission_full_screen_intent_title),
+                context.getString(R.string.permission_full_screen_intent_description)
+            )
+        }
     }
 
     // check whether we need any permissions without actually requesting them
@@ -149,7 +161,8 @@ class PermissionManager(private val context: Context, private val activity: AppC
         if (!checkUsageStatsPermissions(false) ||
             !checkScheduleExactAlarmPermissions(false) ||
             !checkBackgroundLocationPermissions(false) ||
-            !checkOverlayPermissions(false)
+            !checkOverlayPermissions(false) ||
+            !checkFullScreenIntentPermissions(false)
         ) {
             DebugLogger.d(tag, context.getString(R.string.debug_log_still_need_some_permissions))
             return true
@@ -184,7 +197,8 @@ class PermissionManager(private val context: Context, private val activity: AppC
         return if (!checkUsageStatsPermissions(true) ||
             !checkScheduleExactAlarmPermissions(true) ||
             !checkBackgroundLocationPermissions(true) ||
-            !checkOverlayPermissions(true)
+            !checkOverlayPermissions(true) ||
+            !checkFullScreenIntentPermissions(true)
         ) {
             DebugLogger.d(tag, context.getString(R.string.debug_log_finished_requesting_permissions))
             false
@@ -252,6 +266,13 @@ class PermissionManager(private val context: Context, private val activity: AppC
                 // request the permission by taking the user to the settings page
                 Log.d(tag, "Requesting setting permission: $permission")
                 val myIntent = Intent(permission)
+
+                // the full-screen intent settings action expects a package URI
+                //  so it opens directly on this app's toggle
+                if (permission == Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT) {
+                    myIntent.data = Uri.fromParts("package", context.packageName, null)
+                }
+
                 activity?.startActivity(myIntent) ?: run {
                     myIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     context.startActivity(myIntent)
@@ -361,6 +382,39 @@ class PermissionManager(private val context: Context, private val activity: AppC
         } else {
             Log.d(tag, "Don't have fine location permissions?!")
             return false
+        }
+    }
+
+    private fun checkFullScreenIntentPermissions(requestPermissions: Boolean): Boolean {
+
+        // only needed when the user has the full-screen prompt enabled; the
+        //  special access exists from API 34 and is granted at install below that
+        if (!overlayPromptEnabled || Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return true
+        }
+
+        Log.d(tag, "Checking full-screen intent permissions")
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+
+        if (notificationManager != null && !notificationManager.canUseFullScreenIntent()) {
+
+            if (!requestPermissions) {
+                return false
+            }
+
+            explainSettingsPermission(
+                Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT,
+                permissionExplanations[Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT]!![0],
+                permissionExplanations[Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT]!![1]
+            )
+
+            // return false because we haven't actually granted the permission at this point
+            return false
+        } else {
+            Log.d(tag, "Full-screen intent permission already granted!")
+            return true
         }
     }
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -254,9 +254,13 @@
     <!-- REQUEST_SCHEDULE_EXACT_ALARM Permission (For S and above) -->
     <string name="permission_schedule_alarms_title">Erlaubnis erforderlich: Wecker und Erinnerungen</string>
     <string name="permission_schedule_alarms_description">Erinnerungen sind erforderlich, damit der Alarm auch dann ausgelöst werden kann, wenn Ihr Gerät schläft oder sich im Modus \"Nicht stören\" befindet.\n\nBitte aktivieren Sie diese Berechtigung für die KeepAlive-App in Ihren Geräteeinstellungen.</string>
+    <string name="permission_full_screen_intent_title">Berechtigung erforderlich: Vollbildbenachrichtigungen</string>
+    <string name="permission_full_screen_intent_description">Vollbildbenachrichtigungen werden benötigt, um die \'Sind Sie noch da?\'-Abfrage auf dem Sperrbildschirm anzuzeigen, damit sie bei gesperrtem Telefon nicht übersehen werden kann.\n\nBitte aktivieren Sie auf dem nächsten Bildschirm \'Vollbildbenachrichtigungen\' für die Keep Alive App.</string>
 
     <!-- AlertFunctions.kt -->
     <string name="debug_log_doing_alert_check">Führe regelmäßige Überprüfung durch, Alarmphase ist %1$s</string>
+    <string name="debug_log_full_screen_prompt_shown">Vollbild-\'Sind Sie noch da?\'-Abfrage über dem Sperrbildschirm angezeigt</string>
+    <string name="debug_log_full_screen_prompt_acknowledged">Vollbild-\'Sind Sie noch da?\'-Abfrage bestätigt</string>
     <string name="debug_log_sending_alert_sms">Sende Alarm-SMS!</string>
     <string name="debug_log_getting_sms_manager_with_sub_id">Erhalte SMS-Manager mit context.getSystemService und Sub-ID %1$d</string>
     <string name="debug_log_getting_sms_manager_with_context">Erhalte SMS-Manager mit context.getSystemService</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -254,9 +254,13 @@
     <!-- REQUEST_SCHEDULE_EXACT_ALARM Permission (For S and above) -->
     <string name="permission_schedule_alarms_title">Permiso necesario: Programar alarmas</string>
     <string name="permission_schedule_alarms_description">Programar alarmas es necesario para que la alerta pueda activarse incluso cuando tu dispositivo está suspendido o en modo No molestar.\n\nPor favor, activa este permiso para la app KeepAlive en la configuración de tu dispositivo.</string>
+    <string name="permission_full_screen_intent_title">Permiso necesario: Notificaciones a pantalla completa</string>
+    <string name="permission_full_screen_intent_description">Las notificaciones a pantalla completa son necesarias para mostrar la comprobación \'¿Sigues ahí?\' en la pantalla de bloqueo, de modo que no pase desapercibida mientras el teléfono está bloqueado.\n\nActive \'Notificaciones de pantalla completa\' para la aplicación Keep Alive en la siguiente pantalla.</string>
 
     <!-- AlertFunctions.kt -->
     <string name="debug_log_doing_alert_check">Realizando verificación periódica, la etapa de alarma es %1$s</string>
+    <string name="debug_log_full_screen_prompt_shown">Aviso a pantalla completa \'¿Sigues ahí?\' mostrado sobre la pantalla de bloqueo</string>
+    <string name="debug_log_full_screen_prompt_acknowledged">Aviso a pantalla completa \'¿Sigues ahí?\' confirmado</string>
     <string name="debug_log_sending_alert_sms">¡Enviando alerta SMS!</string>
     <string name="debug_log_getting_sms_manager_with_sub_id">Obteniendo el gestor de SMS con context.getSystemService y el id de suscripción %1$d</string>
     <string name="debug_log_getting_sms_manager_with_context">Obteniendo el gestor de SMS con context.getSystemService</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -254,9 +254,13 @@
     <!-- REQUEST_SCHEDULE_EXACT_ALARM Permission (For S and above) -->
     <string name="permission_schedule_alarms_title">Autorisation requise: Planifier des alarmes</string>
     <string name="permission_schedule_alarms_description">La planification des alarmes est requise pour que l\'alerte puisse se déclencher même lorsque votre appareil est en veille ou en mode Ne pas déranger.\n\nVeuillez activer cette autorisation pour l\'application KeepAlive dans les paramètres de votre appareil.</string>
+    <string name="permission_full_screen_intent_title">Autorisation requise : Notifications plein écran</string>
+    <string name="permission_full_screen_intent_description">Les notifications plein écran sont nécessaires pour afficher la vérification \'Êtes-vous là?\' sur l\'écran de verrouillage, afin qu\'elle ne passe pas inaperçue lorsque votre téléphone est verrouillé.\n\nVeuillez activer \'Notifications plein écran\' pour l\'application Keep Alive sur l\'écran suivant.</string>
 
     <!-- AlertFunctions.kt -->
     <string name="debug_log_doing_alert_check">Effectuer une vérification périodique, l\'étape d\'alerte est %1$s</string>
+    <string name="debug_log_full_screen_prompt_shown">Invite plein écran \'Êtes-vous là?\' affichée sur l\'écran de verrouillage</string>
+    <string name="debug_log_full_screen_prompt_acknowledged">Invite plein écran \'Êtes-vous là?\' confirmée</string>
     <string name="debug_log_sending_alert_sms">Envoi d\'un SMS d\'alerte!</string>
     <string name="debug_log_getting_sms_manager_with_sub_id">Obtention du gestionnaire de SMS avec context.getSystemService et l\'identifiant d\'abonnement %1$d</string>
     <string name="debug_log_getting_sms_manager_with_context">Obtention du gestionnaire de SMS avec context.getSystemService</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -254,9 +254,13 @@
         <!-- REQUEST_SCHEDULE_EXACT_ALARM Permission (For S and above) -->  
         <string name="permission_schedule_alarms_title">Autorizzazione richiesta: Pianificare allarmi</string>  
         <string name="permission_schedule_alarms_description">La pianificazione degli allarmi è richiesta affinché l\'avviso possa attivarsi anche quando il tuo dispositivo è inattivo o in modalità Non disturbare.\n\nSi prega di attivare questa autorizzazione per l\'applicazione KeepAlive nelle impostazioni del tuo dispositivo.</string>  
+        <string name="permission_full_screen_intent_title">Autorizzazione richiesta: Notifiche a schermo intero</string>
+        <string name="permission_full_screen_intent_description">Le notifiche a schermo intero sono necessarie per mostrare il controllo \'Ci sei ancora?\' sulla schermata di blocco, in modo che non passi inosservato mentre il telefono è bloccato.\n\nAttiva \'Notifiche a schermo intero\' per l\'app Keep Alive nella schermata successiva.</string>
       
         <!-- AlertFunctions.kt -->  
         <string name="debug_log_doing_alert_check">Esecuzione di una verifica periodica, il passaggio di avviso è %1$s</string>  
+        <string name="debug_log_full_screen_prompt_shown">Avviso a schermo intero \'Ci sei ancora?\' mostrato sopra la schermata di blocco</string>
+        <string name="debug_log_full_screen_prompt_acknowledged">Avviso a schermo intero \'Ci sei ancora?\' confermato</string>
         <string name="debug_log_sending_alert_sms">Invio di un SMS di avviso!</string>  
         <string name="debug_log_getting_sms_manager_with_sub_id">Ottenimento del gestore SMS con context.getSystemService e l\'ID di abbonamento %1$d</string>  
         <string name="debug_log_getting_sms_manager_with_context">Ottenimento del gestore SMS con context.getSystemService</string>  

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -254,9 +254,13 @@
     <!-- REQUEST_SCHEDULE_EXACT_ALARM Permission (For S and above) -->
     <string name="permission_schedule_alarms_title">Wymagane Uprawnienie: Harmonogram Alarmów</string>
     <string name="permission_schedule_alarms_description">Planowanie alarmów jest wymagane, aby Alert mógł być wywołany nawet gdy urządzenie jest uśpione albo w trybie Nie Przeszkadzać.\n\nProszę przyznać to uprawnienie aplikacji KeepAlive w ustawieniach urządzenia.</string>
+    <string name="permission_full_screen_intent_title">Wymagane uprawnienie: Powiadomienia pełnoekranowe</string>
+    <string name="permission_full_screen_intent_description">Powiadomienia pełnoekranowe są potrzebne, aby wyświetlić kontrolę \'Czy nadal tam jesteś?\' na ekranie blokady, tak aby nie została przeoczona, gdy telefon jest zablokowany.\n\nNa następnym ekranie włącz \'Powiadomienia pełnoekranowe\' dla aplikacji Keep Alive.</string>
 
     <!-- AlertFunctions.kt -->
     <string name="debug_log_doing_alert_check">Wykonywanie okresowego sprawdzania, etap alarmu to %1$s</string>
+    <string name="debug_log_full_screen_prompt_shown">Pełnoekranowy monit \'Czy nadal tam jesteś?\' wyświetlony na ekranie blokady</string>
+    <string name="debug_log_full_screen_prompt_acknowledged">Pełnoekranowy monit \'Czy nadal tam jesteś?\' potwierdzony</string>
     <string name="debug_log_sending_alert_sms">Wysyłanie alertu SMS!</string>
     <string name="debug_log_getting_sms_manager_with_sub_id">Pobieranie menedżera SMS za pomocą context.getSystemService i identyfikatora sub %1$d</string>
     <string name="debug_log_getting_sms_manager_with_context">Pobieranie menedżera SMS za pomocą context.getSystemService</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -254,9 +254,13 @@
     <!-- REQUEST_SCHEDULE_EXACT_ALARM Permission (For S and above) -->
     <string name="permission_schedule_alarms_title">Требуется разрешение: Отложенные уведомления</string>
     <string name="permission_schedule_alarms_description">Планирование оповещений необходимо, чтобы оповещение могло срабатывать, даже когда ваше устройство находится в спящем режиме или в режиме \'Не беспокоить\'.\n\nВключите это разрешение для приложения KeepAlive в настройках вашего устройства.</string>
+    <string name="permission_full_screen_intent_title">Требуется разрешение: Полноэкранные уведомления</string>
+    <string name="permission_full_screen_intent_description">Полноэкранные уведомления необходимы, чтобы показывать проверку \'Вы ещё здесь?\' на экране блокировки, чтобы её нельзя было пропустить, пока телефон заблокирован.\n\nНа следующем экране включите \'Полноэкранные уведомления\' для приложения Keep Alive.</string>
 
     <!-- AlertFunctions.kt -->
     <string name="debug_log_doing_alert_check">Выполнение периодической проверки, этап оповещения %1$s</string>
+    <string name="debug_log_full_screen_prompt_shown">Полноэкранный запрос \'Вы ещё здесь?\' показан поверх экрана блокировки</string>
+    <string name="debug_log_full_screen_prompt_acknowledged">Полноэкранный запрос \'Вы ещё здесь?\' подтверждён</string>
     <string name="debug_log_sending_alert_sms">Отправка SMS-оповещения!</string>
     <string name="debug_log_getting_sms_manager_with_sub_id">Получение менеджера SMS с помощью context.getSystemService и идентификатора подписки %1$d</string>
     <string name="debug_log_getting_sms_manager_with_context">Получение менеджера SMS с помощью context.getSystemService</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -254,9 +254,13 @@
     <!-- REQUEST_SCHEDULE_EXACT_ALARM Permission (For S and above) -->
     <string name="permission_schedule_alarms_title">需要授予权限: 闹钟和提醒</string>
     <string name="permission_schedule_alarms_description">需要授予闹钟和提醒权限，这样即使设备处于睡眠或勿扰模式，提醒也能触发。\n\n请在设置中为 KeepAlive 启用此权限。</string>
+    <string name="permission_full_screen_intent_title">需要权限：全屏通知</string>
+    <string name="permission_full_screen_intent_description">需要全屏通知才能在锁定屏幕上显示“您还在吗？”检查，确保手机锁定时不会被错过。\n\n请在下一个屏幕中为 Keep Alive 应用启用“全屏通知”。</string>
 
     <!-- AlertFunctions.kt -->
     <string name="debug_log_doing_alert_check">Doing periodic check, alarm stage is %1$s</string>
+    <string name="debug_log_full_screen_prompt_shown">全屏“您还在吗？”提示已显示在锁定屏幕上</string>
+    <string name="debug_log_full_screen_prompt_acknowledged">全屏“您还在吗？”提示已确认</string>
     <string name="debug_log_sending_alert_sms">Sending alert SMS!</string>
     <string name="debug_log_getting_sms_manager_with_sub_id">Getting SMS manager with context.getSystemService and sub id %1$d</string>
     <string name="debug_log_getting_sms_manager_with_context">Getting SMS manager with context.getSystemService</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,14 @@
     <string name="permission_schedule_alarms_title">Permission Required: Schedule Alarms</string>
     <string name="permission_schedule_alarms_description">Scheduling alarms is required so that the Alert can trigger even when your device is sleeping or in Do Not Disturb mode.\n\nPlease enable this permission for the KeepAlive app in your device settings.</string>
 
+    <!-- USE_FULL_SCREEN_INTENT special access (API 34 and above) -->
+    <string name="permission_full_screen_intent_title">Permission Required: Full Screen Notifications</string>
+    <string name="permission_full_screen_intent_description">Full screen notifications are needed to show the \'Are you there?\' check on the lock screen, so it cannot be missed while your phone is locked.\n\nPlease enable \'Full screen notifications\' for the Keep Alive app on the next screen.</string>
+
+    <!-- AreYouThereActivity.kt -->
+    <string name="debug_log_full_screen_prompt_shown">Full-screen Are you there? prompt shown over lock screen</string>
+    <string name="debug_log_full_screen_prompt_acknowledged">Full-screen Are you there? prompt acknowledged</string>
+
     <!-- AlertFunctions.kt -->
     <string name="debug_log_doing_alert_check">Doing periodic check, alarm stage is %1$s</string>
     <string name="debug_log_sending_alert_sms">Sending alert SMS!</string>

--- a/app/src/test/java/io/keepalive/android/AreYouThereActivityTest.kt
+++ b/app/src/test/java/io/keepalive/android/AreYouThereActivityTest.kt
@@ -1,0 +1,111 @@
+package io.keepalive.android
+
+import android.content.Context
+import android.content.Intent
+import android.os.Looper
+import android.widget.Button
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Tests the full-screen "Are you there?" prompt activity (issue #182):
+ * launched by the system over the lock screen via the notification's
+ * full-screen intent; "I'm OK" acknowledges, and the prompt closes itself
+ * when it is acknowledged elsewhere or its countdown runs out.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AreYouThereActivityTest {
+
+    private val appCtx: Context = ApplicationProvider.getApplicationContext()
+
+    @Before fun setUp() {
+        mockkObject(AcknowledgeAreYouThere)
+        every { AcknowledgeAreYouThere.acknowledge(any()) } returns Unit
+
+        // a final alarm ten minutes out so the countdown doesn't finish the
+        //  activity during the test
+        getAppSharedPreferences(appCtx).edit()
+            .putLong(PrefKeys.NEXT_ALARM_TIMESTAMP, System.currentTimeMillis() + 10 * 60 * 1000L)
+            .commit()
+    }
+
+    @After fun tearDown() {
+        unmockkObject(AcknowledgeAreYouThere)
+        getAppSharedPreferences(appCtx).edit().clear().commit()
+    }
+
+    private fun launch(message: String? = null): AreYouThereActivity {
+        val intent = Intent(appCtx, AreYouThereActivity::class.java)
+        message?.let { intent.putExtra(AreYouThereActivity.EXTRA_MESSAGE, it) }
+        val activity = Robolectric.buildActivity(AreYouThereActivity::class.java, intent)
+            .setup().get()
+        shadowOf(Looper.getMainLooper()).idle()
+        return activity
+    }
+
+    @Test fun `message extra populates the prompt text`() {
+        val activity = launch("Tap to confirm you're OK. Otherwise an alert will be sent in 10 minutes.")
+
+        assertEquals(
+            "Tap to confirm you're OK. Otherwise an alert will be sent in 10 minutes.",
+            activity.findViewById<TextView>(R.id.textAreYouThereMessage).text.toString()
+        )
+        // title always comes from the runtime string, same as the overlay
+        assertEquals(
+            appCtx.getString(R.string.initial_check_notification_title),
+            activity.findViewById<TextView>(R.id.textAreYouThereTitle).text.toString()
+        )
+    }
+
+    @Test fun `im ok button acknowledges and finishes`() {
+        val activity = launch()
+
+        activity.findViewById<Button>(R.id.buttonImOk).performClick()
+
+        verify(exactly = 1) { AcknowledgeAreYouThere.acknowledge(any()) }
+        assertTrue("activity must finish after acknowledging", activity.isFinishing)
+    }
+
+    @Test fun `finishActive closes the showing prompt`() {
+        // acknowledged elsewhere (notification tap, BOOT_COMPLETED) or the
+        //  final alert fired — the prompt must not stay on screen
+        val activity = launch()
+
+        AreYouThereActivity.finishActive()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue("finishActive must finish the showing prompt", activity.isFinishing)
+    }
+
+    @Test fun `finishActive is a no-op with no prompt showing`() {
+        AreYouThereActivity.finishActive()
+        shadowOf(Looper.getMainLooper()).idle()
+        // no crash = pass
+    }
+
+    @Test fun `prompt closes itself when the final alarm time has passed`() {
+        // the alert has fired (or no alarm is scheduled at all) — the prompt
+        //  is no longer actionable
+        getAppSharedPreferences(appCtx).edit()
+            .putLong(PrefKeys.NEXT_ALARM_TIMESTAMP, System.currentTimeMillis() - 1000L)
+            .commit()
+
+        val activity = launch()
+
+        assertTrue("activity must finish once the countdown target has passed",
+            activity.isFinishing)
+    }
+}

--- a/app/src/test/java/io/keepalive/android/FullScreenIntentNotificationTest.kt
+++ b/app/src/test/java/io/keepalive/android/FullScreenIntentNotificationTest.kt
@@ -1,0 +1,107 @@
+package io.keepalive.android
+
+import android.Manifest
+import android.app.Application
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the full-screen intent attachment on the "Are you there?" notification
+ * (issue #182): app overlay windows draw below the keyguard, so the
+ * notification's full-screen intent launching [AreYouThereActivity] is the
+ * only path that makes the prompt visible while the device is locked.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28, 33, 34, 36])
+class FullScreenIntentNotificationTest {
+
+    private val appCtx: Context = ApplicationProvider.getApplicationContext()
+    private val nm = appCtx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    @Before fun setUp() {
+        // USE_FULL_SCREEN_INTENT models the install-time grant (the state on
+        //  sideloaded/F-Droid installs, and on Play installs with the core
+        //  function approved) — canUseFullScreenIntent() consults it on API 34+
+        shadowOf(appCtx as Application).grantPermissions(
+            Manifest.permission.POST_NOTIFICATIONS,
+            Manifest.permission.USE_FULL_SCREEN_INTENT
+        )
+        nm.cancelAll()
+        // explicit default: full-screen prompt enabled (AppController's
+        //  first-run migration writes this in production)
+        getAppSharedPreferences(appCtx).edit()
+            .putBoolean(PrefKeys.ARE_YOU_THERE_OVERLAY_ENABLED, true)
+            .commit()
+    }
+
+    private fun postAreYouThere() {
+        AlertNotificationHelper(appCtx).sendNotification(
+            "Are you still there?",
+            "Tap here to confirm you're OK.",
+            AppController.ARE_YOU_THERE_NOTIFICATION_ID
+        )
+    }
+
+    @Test
+    // pre-34 legs only: this Robolectric version hard-codes
+    //  canUseFullScreenIntent() to false on API 34+ and offers no shadow
+    //  setter, so the granted path can't be simulated there. on 34+ the only
+    //  difference is that two-line gate; the real grant flow is covered by
+    //  on-device testing
+    @Config(sdk = [28, 33])
+    fun `are-you-there notification carries a full-screen intent when enabled`() {
+        postAreYouThere()
+
+        val notif = shadowOf(nm).getNotification(null, AppController.ARE_YOU_THERE_NOTIFICATION_ID)
+        assertNotNull("notification should be posted", notif)
+        assertNotNull("full-screen intent must be attached so the prompt can " +
+                "show over the lock screen", notif.fullScreenIntent)
+    }
+
+    @Test
+    @Config(sdk = [34, 36])
+    fun `notification still posts normally when the special access is not granted on API 34+`() {
+        // Robolectric reports canUseFullScreenIntent() = false here — the same
+        //  state as a fresh Play install without the core-function approval.
+        //  The prompt gracefully degrades: notification posted, no FSI attached.
+        postAreYouThere()
+
+        val notif = shadowOf(nm).getNotification(null, AppController.ARE_YOU_THERE_NOTIFICATION_ID)
+        assertNotNull("notification itself must still be posted", notif)
+        assertNull("no full-screen intent without the special access", notif.fullScreenIntent)
+    }
+
+    @Test fun `no full-screen intent when the full-screen prompt setting is off`() {
+        getAppSharedPreferences(appCtx).edit()
+            .putBoolean(PrefKeys.ARE_YOU_THERE_OVERLAY_ENABLED, false)
+            .commit()
+
+        postAreYouThere()
+
+        val notif = shadowOf(nm).getNotification(null, AppController.ARE_YOU_THERE_NOTIFICATION_ID)
+        assertNotNull("notification itself must still be posted", notif)
+        assertNull("setting off must not attach a full-screen intent", notif.fullScreenIntent)
+    }
+
+    @Test fun `other notifications never carry a full-screen intent`() {
+        AlertNotificationHelper(appCtx).sendNotification(
+            "Keep Alive Alert triggered!",
+            "An SMS has been sent",
+            AppController.SMS_ALERT_SENT_NOTIFICATION_ID
+        )
+
+        val notif = shadowOf(nm).getNotification(null, AppController.SMS_ALERT_SENT_NOTIFICATION_ID)
+        assertNotNull(notif)
+        assertNull(notif.fullScreenIntent)
+    }
+
+}


### PR DESCRIPTION
Implements the plan of record from #182.

## Problem

App overlay windows are layered below the keyguard, so the SYSTEM_ALERT_WINDOW overlay is attached but invisible while the device is locked (confirmed by the reporter's lock-screen test and their debug log's "Overlay shown" line while locked). On a locked phone the only visible prompt was the regular notification.

## Change

The "Are you there?" notification now carries a **full-screen intent** - the mechanism alarm clocks and incoming calls use:

- **Locked / screen off:** the system launches the new `AreYouThereActivity` over the keyguard (`showWhenLocked` + `turnScreenOn`). It reuses the overlay's layout, counts down to the actual final-alarm time, and "I'm OK" acknowledges without requiring an unlock - like dismissing an alarm clock. The keyguard itself stays in place.
- **Unlocked / in use:** the FSI degrades to a heads-up notification and the existing overlay continues to cover the full-screen role, so both surfaces stay.
- The prompt closes itself when acknowledged elsewhere or when the final alert fires (`finishActive()` wired into `AcknowledgeAreYouThere` and the alert pipeline), and is `directBootAware` so before-first-unlock checks can show it too.

## Permission handling

- Gated on the same full-screen prompt setting as the overlay, and on API 34+ on `canUseFullScreenIntent()`.
- `PermissionManager` gains a check that routes the user to the Full Screen special access page (`ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT` with the package URI) when the setting is on but the access is missing.
- Sideloaded / F-Droid / Obtainium installs keep the install-time grant; on Android 14+ the **Play Store** revokes it at install unless the calling/alarm core-function declaration is approved - the graceful-degradation path (notification without FSI + the permission prompt) is the documented compliant behavior either way.

## Play Console (manual, ships with this release)

The full-screen intent declaration in Play Console -> App content needs to be completed when this ships to Play. If the declaration is not approved, the feature still works via the user grant flow above.

## Tests

- `FullScreenIntentNotificationTest`: FSI attached when enabled (pre-34 legs), never on other notifications, not when the setting is off, and graceful degradation on API 34+ where Robolectric models the revoked state.
- `AreYouThereActivityTest`: message population, I'm-OK acknowledge+finish, `finishActive()`, self-close when the alarm time has passed.
- Full unit suite and lint pass; instrumented sources compile.

On-device verification on GrapheneOS / Android 17 (locked-screen launch, BFU behavior) is the part emulators can't meaningfully cover - the reporter has offered to test.

Fixes #182